### PR TITLE
fix: guard segment info paths against traversal

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/FileUtils.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/FileUtils.java
@@ -42,6 +42,7 @@ import java.nio.channels.FileChannel;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -453,7 +454,13 @@ public class FileUtils
   public static File resolveFileWithinDirectory(final File directory, final String path)
   {
     final Path normalizedDirectory = directory.toPath().toAbsolutePath().normalize();
-    final Path childPath = Path.of(path);
+    final Path childPath;
+    try {
+      childPath = Path.of(path);
+    }
+    catch (InvalidPathException e) {
+      throw new IAE(e, "Path[%s] is not within directory[%s]", path, directory);
+    }
     if (childPath.isAbsolute()) {
       throw new IAE("Path[%s] is not within directory[%s]", path, directory);
     }

--- a/processing/src/main/java/org/apache/druid/java/util/common/FileUtils.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/FileUtils.java
@@ -446,6 +446,24 @@ public class FileUtils
     return new File(parentDirectory).toPath();
   }
 
+  /**
+   * Resolves {@code path} below {@code directory}, rejecting absolute paths and parent traversal that would escape it.
+   * This is intended for paths containing externally supplied identifiers.
+   */
+  public static File resolveFileWithinDirectory(final File directory, final String path)
+  {
+    final Path normalizedDirectory = directory.toPath().toAbsolutePath().normalize();
+    final Path childPath = Path.of(path);
+    if (childPath.isAbsolute()) {
+      throw new IAE("Path[%s] is not within directory[%s]", path, directory);
+    }
+    final Path resolvedPath = normalizedDirectory.resolve(childPath).normalize();
+    if (!resolvedPath.startsWith(normalizedDirectory)) {
+      throw new IAE("Path[%s] is not within directory[%s]", path, directory);
+    }
+    return resolvedPath.toFile();
+  }
+
   @SuppressForbidden(reason = "Files#createTempDirectory")
   public static File createTempDirInLocation(final Path parentDirectory, @Nullable final String prefix)
   {

--- a/processing/src/test/java/org/apache/druid/java/util/common/FileUtilsTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/FileUtilsTest.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class FileUtilsTest
 {
@@ -169,6 +170,38 @@ public class FileUtilsTest
       return null;
     });
     Assertions.assertEquals("baz", StringUtils.fromUtf8(Files.readAllBytes(tmpFile.toPath())));
+  }
+
+  @Test
+  public void testResolveFileWithinDirectory()
+  {
+    final File resolved = FileUtils.resolveFileWithinDirectory(temporaryFolder, "nested/file");
+
+    Assertions.assertEquals(
+        temporaryFolder.toPath().toAbsolutePath().resolve(Path.of("nested", "file")).normalize(),
+        resolved.toPath()
+    );
+  }
+
+  @Test
+  public void testResolveFileWithinDirectoryRejectsTraversal()
+  {
+    Assertions.assertThrows(
+        IAE.class,
+        () -> FileUtils.resolveFileWithinDirectory(temporaryFolder, "../outside")
+    );
+  }
+
+  @Test
+  public void testResolveFileWithinDirectoryRejectsAbsolutePath()
+  {
+    Assertions.assertThrows(
+        IAE.class,
+        () -> FileUtils.resolveFileWithinDirectory(
+            temporaryFolder,
+            temporaryFolder.toPath().resolve("inside").toAbsolutePath().toString()
+        )
+    );
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/java/util/common/FileUtilsTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/FileUtilsTest.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
 public class FileUtilsTest
@@ -202,6 +203,21 @@ public class FileUtilsTest
             temporaryFolder.toPath().resolve("inside").toAbsolutePath().toString()
         )
     );
+  }
+
+  @Test
+  public void testResolveFileWithinDirectoryRejectsInvalidPath()
+  {
+    final IAE exception = Assertions.assertThrows(
+        IAE.class,
+        () -> FileUtils.resolveFileWithinDirectory(temporaryFolder, "invalid\0path")
+    );
+
+    Assertions.assertEquals(
+        StringUtils.format("Path[%s] is not within directory[%s]", "invalid\0path", temporaryFolder),
+        exception.getMessage()
+    );
+    Assertions.assertInstanceOf(InvalidPathException.class, exception.getCause());
   }
 
   @Test

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -33,6 +33,7 @@ import org.apache.druid.client.DataSegmentAndLoadProfile;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Stopwatch;
 import org.apache.druid.java.util.common.concurrent.Execs;
@@ -461,9 +462,16 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
     }
   }
 
-  private void deleteSegmentInfoFile(DataSegment segment)
+  private void deleteSegmentInfoFile(final DataSegment segment)
   {
-    final File segmentInfoCacheFile = getSegmentInfoFile(segment);
+    final File segmentInfoCacheFile;
+    try {
+      segmentInfoCacheFile = getSegmentInfoFile(segment);
+    }
+    catch (IAE e) {
+      log.warn(e, "Refusing to delete info file with invalid path for segment[%s].", segment.getId());
+      return;
+    }
     if (!segmentInfoCacheFile.delete()) {
       log.warn("Unable to delete cache file[%s] for segment[%s].", segmentInfoCacheFile, segment.getId());
     }

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -417,10 +417,15 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
     return files == null ? new File[0] : files;
   }
 
+  private File getSegmentInfoFile(final DataSegment segment)
+  {
+    return FileUtils.resolveFileWithinDirectory(getEffectiveInfoDir(), segment.getId().toString());
+  }
+
   @Override
   public void storeInfoFile(final DataSegment segment) throws IOException
   {
-    final File segmentInfoCacheFile = new File(getEffectiveInfoDir(), segment.getId().toString());
+    final File segmentInfoCacheFile = getSegmentInfoFile(segment);
     if (!segmentInfoCacheFile.exists()) {
       FileUtils.mkdirp(segmentInfoCacheFile.getParentFile());
       FileUtils.writeAtomically(
@@ -458,7 +463,7 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
 
   private void deleteSegmentInfoFile(DataSegment segment)
   {
-    final File segmentInfoCacheFile = new File(getEffectiveInfoDir(), segment.getId().toString());
+    final File segmentInfoCacheFile = getSegmentInfoFile(segment);
     if (!segmentInfoCacheFile.delete()) {
       log.warn("Unable to delete cache file[%s] for segment[%s].", segmentInfoCacheFile, segment.getId());
     }
@@ -473,7 +478,7 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
    */
   private void writePartialInfoFile(DataSegment segment) throws IOException
   {
-    final File segmentInfoCacheFile = new File(getEffectiveInfoDir(), segment.getId().toString());
+    final File segmentInfoCacheFile = getSegmentInfoFile(segment);
     FileUtils.mkdirp(getEffectiveInfoDir());
     FileUtils.writeAtomically(segmentInfoCacheFile, out -> {
       jsonMapper.writeValue(out, segment);
@@ -530,7 +535,7 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
           try {
             if (hold != null) {
               // write the segment info file if it doesn't exist. this can happen if we are loading after a drop
-              final File segmentInfoCacheFile = new File(getEffectiveInfoDir(), dataSegment.getId().toString());
+              final File segmentInfoCacheFile = getSegmentInfoFile(dataSegment);
               if (!segmentInfoCacheFile.exists()) {
                 FileUtils.mkdirp(getEffectiveInfoDir());
                 FileUtils.writeAtomically(segmentInfoCacheFile, out -> {

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.guice.LocalDataStorageDruidModule;
 import org.apache.druid.jackson.SegmentizerModule;
 import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -59,6 +60,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -245,6 +247,26 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
     Assert.assertTrue(manager.canHandleSegments());
     assertThat(manager.getCachedSegments(), containsInAnyOrder(segment1, segment2));
     Assert.assertFalse(segment3InfoFile.exists());
+  }
+
+  @Test
+  public void testSegmentInfoFileRejectsPathTraversal() throws IOException
+  {
+    final DataSegment segment = TestSegmentUtils.makeSegment(
+        "../../outside",
+        "v0",
+        Intervals.of("2014-10-20T00:00:00Z/P1D")
+    );
+    final File infoDir = new File(localSegmentCacheDir, "info_dir");
+    final File unsafeInfoFile = new File(infoDir, segment.getId().toString());
+    FileUtils.mkdirp(infoDir);
+
+    Assert.assertThrows(IAE.class, () -> manager.storeInfoFile(segment));
+    Assert.assertFalse(unsafeInfoFile.exists());
+
+    Files.write(unsafeInfoFile.toPath(), new byte[]{1});
+    Assert.assertThrows(IAE.class, () -> manager.removeInfoFile(segment));
+    Assert.assertTrue(unsafeInfoFile.exists());
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
@@ -265,7 +265,7 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
     Assert.assertFalse(unsafeInfoFile.exists());
 
     Files.write(unsafeInfoFile.toPath(), new byte[]{1});
-    Assert.assertThrows(IAE.class, () -> manager.removeInfoFile(segment));
+    manager.removeInfoFile(segment);
     Assert.assertTrue(unsafeInfoFile.exists());
   }
 


### PR DESCRIPTION
## Summary

- add a shared helper that resolves a relative path only when its normalized result remains beneath the intended directory
- reject absolute paths, including absolute paths that happen to point beneath the configured directory
- use the helper consistently for complete and partial segment info-file writes and deletion
- cover legitimate nested paths, `..` traversal, absolute paths, and preservation of an out-of-directory sentinel

## Root cause

`SegmentLocalCacheManager` constructed info-file paths directly from `DataSegment#getId()`. A segment identifier includes externally supplied data-source text, so a crafted identifier containing parent components could make the delete sink reported by CodeQL alert #7450 resolve outside the owned `info_dir`. The same construction was used by the corresponding info-file write paths.

## Fix and impact

Segment info paths are now normalized and required to remain under the configured info directory before any file operation. Absolute paths are rejected explicitly. Normal relative paths, including legitimate nested relative paths, continue to resolve normally. This affects only invalid segment identifiers that would escape the configured info directory.

## Validation

- `mvn -ntp -Pskip-static-checks -pl processing -DskipITs -Dtest=FileUtilsTest test` — 20 tests passed
- `mvn -ntp -Pskip-static-checks -pl server -am -DskipITs -Dtest=SegmentLocalCacheManagerTest -Dsurefire.failIfNoSpecifiedTests=false test` — 31 tests passed
- `mvn -ntp -pl processing,server -DskipTests validate` — Checkstyle, PMD, and Maven enforcer passed for both modules
- `git diff --check`
