### PR TITLE
fix(test): wait for Kafka partitions before publishing

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
@@ -21,7 +21,6 @@ package org.apache.druid.indexing.kafka.simulate;
 
 import org.apache.druid.indexing.kafka.KafkaConsumerConfigs;
 import org.apache.druid.indexing.kafka.KafkaIndexTaskModule;
-import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.apache.druid.testing.embedded.StreamIngestResource;
 import org.apache.kafka.clients.admin.Admin;
@@ -35,7 +34,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.testcontainers.kafka.KafkaContainer;
@@ -56,8 +54,6 @@ import java.util.concurrent.ThreadLocalRandom;
  */
 public class KafkaResource extends StreamIngestResource<KafkaContainer>
 {
-  private static final int PARTITION_READINESS_MAX_TRIES = 5;
-
   /**
    * Kafka Docker image used in embedded tests. The image name is
    * read from the system property {@code druid.testing.kafka.image} and
@@ -316,17 +312,7 @@ public class KafkaResource extends StreamIngestResource<KafkaContainer>
     for (int partition = 0; partition < partitionCount; partition++) {
       partitionOffsets.put(new TopicPartition(topic, partition), OffsetSpec.latest());
     }
-    RetryUtils.retry(
-        () -> admin.listOffsets(partitionOffsets).all().get(),
-        KafkaResource::isRetriableKafkaException,
-        PARTITION_READINESS_MAX_TRIES
-    );
-  }
-
-  private static boolean isRetriableKafkaException(Throwable throwable)
-  {
-    return throwable instanceof RetriableException
-           || throwable.getCause() != null && isRetriableKafkaException(throwable.getCause());
+    admin.listOffsets(partitionOffsets).all().get();
   }
 
   private Map<String, Object> commonClientProperties()

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
@@ -137,6 +137,7 @@ public class KafkaResource extends StreamIngestResource<KafkaContainer>
       admin.createTopics(
           List.of(new NewTopic(topicName, numPartitions, (short) 1))
       ).all().get();
+      waitForPartitionsToBeReady(admin, topicName, numPartitions);
     }
     catch (Exception e) {
       throw new RuntimeException(e);
@@ -178,15 +179,7 @@ public class KafkaResource extends StreamIngestResource<KafkaContainer>
       );
 
       result.values().get(topic).get();
-
-      // createPartitions() may complete before the new partition leaders are
-      // ready to handle requests. Verify all partitions through their leaders
-      // before allowing callers to publish records.
-      final Map<TopicPartition, OffsetSpec> partitionOffsets = new HashMap<>();
-      for (int partition = 0; partition < newPartitionCount; partition++) {
-        partitionOffsets.put(new TopicPartition(topic, partition), OffsetSpec.latest());
-      }
-      admin.listOffsets(partitionOffsets).all().get();
+      waitForPartitionsToBeReady(admin, topic, newPartitionCount);
     }
     catch (Exception e) {
       throw new RuntimeException(e);
@@ -308,6 +301,18 @@ public class KafkaResource extends StreamIngestResource<KafkaContainer>
       producerProperties.putAll(extraProperties);
     }
     return new KafkaProducer<>(producerProperties);
+  }
+
+  private void waitForPartitionsToBeReady(Admin admin, String topic, int partitionCount) throws Exception
+  {
+    // Topic and partition creation may complete before the partition leaders
+    // are ready to handle requests. Verify all partitions through their
+    // leaders before allowing callers to publish records.
+    final Map<TopicPartition, OffsetSpec> partitionOffsets = new HashMap<>();
+    for (int partition = 0; partition < partitionCount; partition++) {
+      partitionOffsets.put(new TopicPartition(topic, partition), OffsetSpec.latest());
+    }
+    admin.listOffsets(partitionOffsets).all().get();
   }
 
   private Map<String, Object> commonClientProperties()

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
@@ -27,10 +27,12 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.CreatePartitionsResult;
 import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
@@ -41,6 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -162,9 +165,9 @@ public class KafkaResource extends StreamIngestResource<KafkaContainer>
   }
 
   /**
-   * Increases the number of partitions in the given Kakfa topic. The topic must
-   * already exist. This method waits until the increase in the partition count
-   * has started (but not necessarily finished).
+   * Increases the number of partitions in the given Kafka topic. The topic must
+   * already exist. This method waits until every partition is ready to handle
+   * requests.
    */
   @Override
   public void increasePartitionsInTopic(String topic, int newPartitionCount)
@@ -174,8 +177,16 @@ public class KafkaResource extends StreamIngestResource<KafkaContainer>
           Map.of(topic, NewPartitions.increaseTo(newPartitionCount))
       );
 
-      // Wait for the partitioning to start
       result.values().get(topic).get();
+
+      // createPartitions() may complete before the new partition leaders are
+      // ready to handle requests. Verify all partitions through their leaders
+      // before allowing callers to publish records.
+      final Map<TopicPartition, OffsetSpec> partitionOffsets = new HashMap<>();
+      for (int partition = 0; partition < newPartitionCount; partition++) {
+        partitionOffsets.put(new TopicPartition(topic, partition), OffsetSpec.latest());
+      }
+      admin.listOffsets(partitionOffsets).all().get();
     }
     catch (Exception e) {
       throw new RuntimeException(e);
@@ -218,8 +229,12 @@ public class KafkaResource extends StreamIngestResource<KafkaContainer>
     props.remove(ProducerConfig.TRANSACTIONAL_ID_CONFIG);
 
     try (final KafkaProducer<byte[], byte[]> kafkaProducer = new KafkaProducer<>(props)) {
-      for (ProducerRecord<byte[], byte[]> record : records) {
-        kafkaProducer.send(record);
+      final List<Future<RecordMetadata>> sendResults = new ArrayList<>(records.size());
+      for (final ProducerRecord<byte[], byte[]> record : records) {
+        sendResults.add(kafkaProducer.send(record));
+      }
+      for (final Future<RecordMetadata> sendResult : sendResults) {
+        sendResult.get();
       }
     }
     catch (Exception e) {

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.kafka.simulate;
 
 import org.apache.druid.indexing.kafka.KafkaConsumerConfigs;
 import org.apache.druid.indexing.kafka.KafkaIndexTaskModule;
+import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.apache.druid.testing.embedded.StreamIngestResource;
 import org.apache.kafka.clients.admin.Admin;
@@ -34,6 +35,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.testcontainers.kafka.KafkaContainer;
@@ -54,6 +56,8 @@ import java.util.concurrent.ThreadLocalRandom;
  */
 public class KafkaResource extends StreamIngestResource<KafkaContainer>
 {
+  private static final int PARTITION_READINESS_MAX_TRIES = 5;
+
   /**
    * Kafka Docker image used in embedded tests. The image name is
    * read from the system property {@code druid.testing.kafka.image} and
@@ -312,7 +316,17 @@ public class KafkaResource extends StreamIngestResource<KafkaContainer>
     for (int partition = 0; partition < partitionCount; partition++) {
       partitionOffsets.put(new TopicPartition(topic, partition), OffsetSpec.latest());
     }
-    admin.listOffsets(partitionOffsets).all().get();
+    RetryUtils.retry(
+        () -> admin.listOffsets(partitionOffsets).all().get(),
+        KafkaResource::isRetriableKafkaException,
+        PARTITION_READINESS_MAX_TRIES
+    );
+  }
+
+  private static boolean isRetriableKafkaException(Throwable throwable)
+  {
+    return throwable instanceof RetriableException
+           || throwable.getCause() != null && isRetriableKafkaException(throwable.getCause());
   }
 
   private Map<String, Object> commonClientProperties()

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResourceTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResourceTest.java
@@ -23,6 +23,7 @@ import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -58,8 +59,19 @@ public class KafkaResourceTest
 
     // Test topic creation
     final String topicName = "test-topic";
-    resource.createTopicWithPartitions(topicName, 3);
+    resource.createTopicWithPartitions(topicName, 2);
     assertEquals(Set.of(topicName), resource.listTopics());
+
+    // Verify that records can be published immediately after adding partitions.
+    resource.increasePartitionsInTopic(topicName, 4);
+    resource.publishRecordsToTopicWithoutTransaction(
+        topicName,
+        Collections.nCopies(1_000, new byte[]{1})
+    );
+    final Map<String, Long> partitionOffsets = resource.getPartitionOffsets(topicName);
+    assertEquals(4, partitionOffsets.size());
+    assertEquals(1_000, partitionOffsets.values().stream().mapToLong(Long::longValue).sum());
+
     resource.deleteTopic(topicName);
 
     resource.stop();

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResourceTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResourceTest.java
@@ -81,15 +81,17 @@ public class KafkaResourceTest
     resource.createTopicWithPartitions(expandedTopicName, 2);
     resource.increasePartitionsInTopic(expandedTopicName, 4);
 
-    // Verify that newly added partitions can accept records immediately.
+    // Verify that every partition can accept records immediately after increasing the partition count.
     resource.produceRecordsWithoutTransaction(
         List.of(
+            new ProducerRecord<>(expandedTopicName, 0, null, new byte[]{1}),
+            new ProducerRecord<>(expandedTopicName, 1, null, new byte[]{1}),
             new ProducerRecord<>(expandedTopicName, 2, null, new byte[]{1}),
             new ProducerRecord<>(expandedTopicName, 3, null, new byte[]{1})
         )
     );
     assertEquals(
-        Map.of("0", 0L, "1", 0L, "2", 1L, "3", 1L),
+        Map.of("0", 1L, "1", 1L, "2", 1L, "3", 1L),
         resource.getPartitionOffsets(expandedTopicName)
     );
     resource.deleteTopic(expandedTopicName);

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResourceTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResourceTest.java
@@ -20,10 +20,11 @@
 package org.apache.druid.indexing.kafka.simulate;
 
 import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -59,30 +60,39 @@ public class KafkaResourceTest
 
     // Test topic creation
     final String topicName = "test-topic";
-    resource.createTopicWithPartitions(topicName, 2);
+    resource.createTopicWithPartitions(topicName, 3);
     assertEquals(Set.of(topicName), resource.listTopics());
 
-    // Verify that records can be published immediately after creating a topic.
-    resource.publishRecordsToTopicWithoutTransaction(
-        topicName,
-        Collections.nCopies(100, new byte[]{1})
+    // Verify that every partition can accept records immediately after creating a topic.
+    resource.produceRecordsWithoutTransaction(
+        List.of(
+            new ProducerRecord<>(topicName, 0, null, new byte[]{1}),
+            new ProducerRecord<>(topicName, 1, null, new byte[]{1}),
+            new ProducerRecord<>(topicName, 2, null, new byte[]{1})
+        )
     );
     assertEquals(
-        100,
-        resource.getPartitionOffsets(topicName).values().stream().mapToLong(Long::longValue).sum()
+        Map.of("0", 1L, "1", 1L, "2", 1L),
+        resource.getPartitionOffsets(topicName)
     );
-
-    // Verify that records can be published immediately after adding partitions.
-    resource.increasePartitionsInTopic(topicName, 4);
-    resource.publishRecordsToTopicWithoutTransaction(
-        topicName,
-        Collections.nCopies(1_000, new byte[]{1})
-    );
-    final Map<String, Long> partitionOffsets = resource.getPartitionOffsets(topicName);
-    assertEquals(4, partitionOffsets.size());
-    assertEquals(1_100, partitionOffsets.values().stream().mapToLong(Long::longValue).sum());
-
     resource.deleteTopic(topicName);
+
+    final String expandedTopicName = "test-expanded-topic";
+    resource.createTopicWithPartitions(expandedTopicName, 2);
+    resource.increasePartitionsInTopic(expandedTopicName, 4);
+
+    // Verify that newly added partitions can accept records immediately.
+    resource.produceRecordsWithoutTransaction(
+        List.of(
+            new ProducerRecord<>(expandedTopicName, 2, null, new byte[]{1}),
+            new ProducerRecord<>(expandedTopicName, 3, null, new byte[]{1})
+        )
+    );
+    assertEquals(
+        Map.of("0", 0L, "1", 0L, "2", 1L, "3", 1L),
+        resource.getPartitionOffsets(expandedTopicName)
+    );
+    resource.deleteTopic(expandedTopicName);
 
     resource.stop();
     assertFalse(resource.isRunning());

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResourceTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResourceTest.java
@@ -62,6 +62,16 @@ public class KafkaResourceTest
     resource.createTopicWithPartitions(topicName, 2);
     assertEquals(Set.of(topicName), resource.listTopics());
 
+    // Verify that records can be published immediately after creating a topic.
+    resource.publishRecordsToTopicWithoutTransaction(
+        topicName,
+        Collections.nCopies(100, new byte[]{1})
+    );
+    assertEquals(
+        100,
+        resource.getPartitionOffsets(topicName).values().stream().mapToLong(Long::longValue).sum()
+    );
+
     // Verify that records can be published immediately after adding partitions.
     resource.increasePartitionsInTopic(topicName, 4);
     resource.publishRecordsToTopicWithoutTransaction(
@@ -70,7 +80,7 @@ public class KafkaResourceTest
     );
     final Map<String, Long> partitionOffsets = resource.getPartitionOffsets(topicName);
     assertEquals(4, partitionOffsets.size());
-    assertEquals(1_000, partitionOffsets.values().stream().mapToLong(Long::longValue).sum());
+    assertEquals(1_100, partitionOffsets.values().stream().mapToLong(Long::longValue).sum());
 
     resource.deleteTopic(topicName);
 


### PR DESCRIPTION
### Description

This fixes a race in the embedded Kafka test resource that was exposed by the failed `KafkaIndexFaultToleranceTest` run in #19754. The failure is unrelated to that PR's dependency changes.

After creating a topic or increasing its partition count, the Kafka admin operation can complete before the partition leaders are ready to serve requests. The test helper immediately created an idempotent producer and published records, which could receive `NOT_LEADER_OR_FOLLOWER` followed by repeated `OUT_OF_ORDER_SEQUENCE_NUMBER` responses. Because the helper ignored the futures returned by `KafkaProducer.send()`, it could return after silently dropping records; the ingestion test then timed out waiting for rows that never reached Kafka.

This PR:

- waits for a successful latest-offset lookup through every partition leader after creating a topic or increasing its partition count;
- waits for every non-transactional producer send result, so delivery failures are surfaced;
- adds a regression test that publishes immediately after both topic creation and partition expansion and verifies that all records arrive.

There is no end-user behavior change.

##### Key changed classes

- `KafkaResource`
- `KafkaResourceTest`

This PR has:

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever it would not be obvious.
- [x] added or updated tests to cover the changed behavior.
- [x] run the exact embedded test that originally failed.

### Tests

```text
mvn -ntp test -pl extensions-core/kafka-indexing-service -am \
  -Dtest="org.apache.druid.indexing.kafka.simulate.KafkaResourceTest" \
  -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks \
  -Dweb.console.skip=true -T1C

mvn -ntp test -pl embedded-tests -am \
  -Dtest="org.apache.druid.testing.embedded.indexing.KafkaIndexFaultToleranceTest#test_supervisorRecovers_afterChangeInTopicPartitions" \
  -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks \
  -Dweb.console.skip=true -T1C

mvn -ntp test -pl embedded-tests -am \
  -Dtest="org.apache.druid.testing.embedded.indexing.autoscaler.CostBasedAutoScalerIntegrationTest#test_autoScaler_scalesUpAndDown_withSlowPublish" \
  -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks \
  -Dweb.console.skip=true -T1C
```

All pass locally. The fault-tolerance test runs both transactional and non-transactional parameterizations.
