### PR TITLE
test: replace deprecated JUnit assertThat calls

### DIFF
--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -96,3 +96,6 @@ javax.annotation.concurrent.GuardedBy
 com.amazonaws.annotation.GuardedBy
 
 org.powermock.** @ Use Mockito instead of Powermock for compatibility with newer Java versions
+
+org.junit.Assert#assertThat(java.lang.Object,org.hamcrest.Matcher) @ Use org.hamcrest.MatcherAssert#assertThat instead
+org.junit.Assert#assertThat(java.lang.String,java.lang.Object,org.hamcrest.Matcher) @ Use org.hamcrest.MatcherAssert#assertThat instead

--- a/extensions-contrib/compressed-bigdecimal/src/test/java/org/apache/druid/compressedbigdecimal/aggregator/CompressedBigDecimalAggregatorGroupByTestBase.java
+++ b/extensions-contrib/compressed-bigdecimal/src/test/java/org/apache/druid/compressedbigdecimal/aggregator/CompressedBigDecimalAggregatorGroupByTestBase.java
@@ -28,6 +28,7 @@ import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.query.aggregation.AggregationTestHelper;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
 import org.apache.druid.query.groupby.ResultRow;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.collection.IsMapWithSize;
@@ -107,7 +108,7 @@ public abstract class CompressedBigDecimalAggregatorGroupByTestBase
     );
 
     List<ResultRow> results = seq.toList();
-    Assert.assertThat(results, IsCollectionWithSize.hasSize(1));
+    MatcherAssert.assertThat(results, IsCollectionWithSize.hasSize(1));
     ResultRow row = results.get(0);
     MapBasedRow mapBasedRow = row.toMapBasedRow(cbdGroupByQueryConfig.getQuery());
     Map<String, Object> event = mapBasedRow.getEvent();
@@ -115,8 +116,8 @@ public abstract class CompressedBigDecimalAggregatorGroupByTestBase
         new DateTime("2017-01-01T00:00:00Z", DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC"))),
         mapBasedRow.getTimestamp()
     );
-    Assert.assertThat(event, IsMapWithSize.aMapWithSize(3));
-    Assert.assertThat(
+    MatcherAssert.assertThat(event, IsMapWithSize.aMapWithSize(3));
+    MatcherAssert.assertThat(
         event,
         IsMapContaining.hasEntry(
             "cbdRevenueFromString",
@@ -124,7 +125,7 @@ public abstract class CompressedBigDecimalAggregatorGroupByTestBase
         )
     );
     // long conversion of 5000000000.000000005 results in null/0 value
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         event,
         IsMapContaining.hasEntry(
             "cbdRevenueFromLong",
@@ -132,7 +133,7 @@ public abstract class CompressedBigDecimalAggregatorGroupByTestBase
         )
     );
     // double input changes 5000000000.000000005 to 5000000000.5 to fit in double mantissa space
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         event,
         IsMapContaining.hasEntry(
             "cbdRevenueFromDouble",

--- a/extensions-contrib/compressed-bigdecimal/src/test/java/org/apache/druid/compressedbigdecimal/aggregator/CompressedBigDecimalAggregatorTimeseriesTestBase.java
+++ b/extensions-contrib/compressed-bigdecimal/src/test/java/org/apache/druid/compressedbigdecimal/aggregator/CompressedBigDecimalAggregatorTimeseriesTestBase.java
@@ -53,10 +53,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public abstract class CompressedBigDecimalAggregatorTimeseriesTestBase extends InitializedNullHandlingTest
 {

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageIterableTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageIterableTest.java
@@ -35,6 +35,7 @@ import org.apache.druid.query.movingaverage.averagers.ConstantAveragerFactory;
 import org.apache.druid.query.movingaverage.averagers.LongMeanAveragerFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
 import org.junit.Assert;
@@ -144,7 +145,7 @@ public class MovingAverageIterableTest extends InitializedNullHandlingTest
     r = iter.next();
     Assert.assertEquals(JAN_3, r.getTimestamp());
     Assert.assertEquals("US", r.getRaw(COUNTRY));
-    Assert.assertThat(r.getRaw(AGE), CoreMatchers.not(CoreMatchers.equalTo(r2.getRaw(AGE))));
+    MatcherAssert.assertThat(r.getRaw(AGE), CoreMatchers.not(CoreMatchers.equalTo(r2.getRaw(AGE))));
 
     Assert.assertTrue(iter.hasNext());
     r = iter.next();

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageQueryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageQueryTest.java
@@ -78,6 +78,7 @@ import org.apache.druid.server.metrics.SubqueryCountStatsProvider;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.TimelineLookup;
 import org.apache.druid.utils.JvmUtils;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsInstanceOf;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -303,11 +304,11 @@ public class MovingAverageQueryTest extends InitializedNullHandlingTest
   public void testQuery() throws IOException
   {
     Query<?> query = jsonMapper.readValue(getQueryString(), Query.class);
-    Assert.assertThat(query, IsInstanceOf.instanceOf(getExpectedQueryType()));
+    MatcherAssert.assertThat(query, IsInstanceOf.instanceOf(getExpectedQueryType()));
 
     List<MapBasedRow> expectedResults = jsonMapper.readValue(getExpectedResultString(), getExpectedResultType());
     Assert.assertNotNull(expectedResults);
-    Assert.assertThat(expectedResults, IsInstanceOf.instanceOf(List.class));
+    MatcherAssert.assertThat(expectedResults, IsInstanceOf.instanceOf(List.class));
 
     DruidHttpClientConfig httpClientConfig = new DruidHttpClientConfig()
     {

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMaxAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMaxAveragerFactoryTest.java
@@ -20,7 +20,7 @@
 package org.apache.druid.query.movingaverage.averagers;
 
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
 public class DoubleMaxAveragerFactoryTest
@@ -29,6 +29,6 @@ public class DoubleMaxAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new DoubleMaxAveragerFactory("test", 5, 1, "field");
-    Assert.assertThat(fac.createAverager(), CoreMatchers.instanceOf(DoubleMaxAverager.class));
+    MatcherAssert.assertThat(fac.createAverager(), CoreMatchers.instanceOf(DoubleMaxAverager.class));
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMeanAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMeanAveragerFactoryTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class DoubleMeanAveragerFactoryTest
@@ -29,6 +29,6 @@ public class DoubleMeanAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new DoubleMeanAveragerFactory("test", 5, 1, "field");
-    Assert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(DoubleMeanAverager.class));
+    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(DoubleMeanAverager.class));
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMeanNoNullAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMeanNoNullAveragerFactoryTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class DoubleMeanNoNullAveragerFactoryTest
@@ -29,6 +29,6 @@ public class DoubleMeanNoNullAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new DoubleMeanNoNullAveragerFactory("test", 5, 1, "field");
-    Assert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(DoubleMeanNoNullAverager.class));
+    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(DoubleMeanNoNullAverager.class));
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMinAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMinAveragerFactoryTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class DoubleMinAveragerFactoryTest
@@ -29,6 +29,6 @@ public class DoubleMinAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new DoubleMinAveragerFactory("test", 5, 1, "field");
-    Assert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(DoubleMinAverager.class));
+    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(DoubleMinAverager.class));
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleSumAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleSumAveragerFactoryTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class DoubleSumAveragerFactoryTest
@@ -30,7 +30,7 @@ public class DoubleSumAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new DoubleSumAveragerFactory("test", 5, 1, "field");
-    Assert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(DoubleSumAverager.class));
+    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(DoubleSumAverager.class));
   }
 
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMaxAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMaxAveragerFactoryTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class LongMaxAveragerFactoryTest
@@ -29,6 +29,6 @@ public class LongMaxAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new LongMaxAveragerFactory("test", 5, 1, "field");
-    Assert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongMaxAverager.class));
+    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongMaxAverager.class));
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMeanAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMeanAveragerFactoryTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class LongMeanAveragerFactoryTest
@@ -29,6 +29,6 @@ public class LongMeanAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new LongMeanAveragerFactory("test", 5, 1, "field");
-    Assert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongMeanAverager.class));
+    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongMeanAverager.class));
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMeanNoNullAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMeanNoNullAveragerFactoryTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class LongMeanNoNullAveragerFactoryTest
@@ -29,6 +29,6 @@ public class LongMeanNoNullAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new LongMeanNoNullAveragerFactory("test", 5, 1, "field");
-    Assert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongMeanNoNullAverager.class));
+    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongMeanNoNullAverager.class));
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMinAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMinAveragerFactoryTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class LongMinAveragerFactoryTest
@@ -29,6 +29,6 @@ public class LongMinAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new LongMinAveragerFactory("test", 5, 1, "field");
-    Assert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongMinAverager.class));
+    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongMinAverager.class));
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongSumAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongSumAveragerFactoryTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class LongSumAveragerFactoryTest
@@ -30,7 +30,7 @@ public class LongSumAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new LongSumAveragerFactory("test", 5, 1, "field");
-    Assert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongSumAverager.class));
+    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongSumAverager.class));
   }
 
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/util/ToObjectVectorColumnProcessorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/util/ToObjectVectorColumnProcessorFactoryTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.vector.VectorCursor;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -168,7 +169,7 @@ public class ToObjectVectorColumnProcessorFactoryTest extends InitializedNullHan
   public void testComplexSketch()
   {
     final Object sketch = Iterables.getOnlyElement(readColumn("quality_uniques", 1));
-    Assert.assertThat(sketch, CoreMatchers.instanceOf(HyperLogLogCollector.class));
+    MatcherAssert.assertThat(sketch, CoreMatchers.instanceOf(HyperLogLogCollector.class));
   }
 
   private CursorHolder makeCursorHolder()

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/QuantilesTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/QuantilesTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -46,7 +47,7 @@ public class QuantilesTest
     );
 
     Object theObject = mapper.readValue(theString, Object.class);
-    Assert.assertThat(theObject, CoreMatchers.instanceOf(LinkedHashMap.class));
+    MatcherAssert.assertThat(theObject, CoreMatchers.instanceOf(LinkedHashMap.class));
 
     LinkedHashMap theMap = (LinkedHashMap) theObject;
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
@@ -136,7 +136,7 @@ public class ParallelIndexSupervisorTaskTest
       int maxPartitionSize = sortedPartitionSizes.get(sortedPartitionSizes.size() - 1);
       int partitionSizeRange = maxPartitionSize - minPartitionSize;
 
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           "partition sizes = " + actualPartitionSizes,
           partitionSizeRange,
           Matchers.is(Matchers.both(Matchers.greaterThanOrEqualTo(0)).and(Matchers.lessThanOrEqualTo(1)))

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTaskTest.java
@@ -35,6 +35,7 @@ import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.server.security.ResourceType;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -92,7 +93,7 @@ public class PartialHashSegmentGenerateTaskTest
   public void hasCorrectPrefixForAutomaticId()
   {
     String id = target.getId();
-    Assert.assertThat(id, Matchers.startsWith(PartialHashSegmentGenerateTask.TYPE));
+    MatcherAssert.assertThat(id, Matchers.startsWith(PartialHashSegmentGenerateTask.TYPE));
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionMultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionMultiPhaseParallelIndexingTest.java
@@ -43,6 +43,7 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.DimensionRangeShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.SingleDimensionShardSpec;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -455,14 +456,14 @@ public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiP
 
     for (StringTuple value : values) {
       if (start != null) {
-        Assert.assertThat(value.compareTo(start), Matchers.greaterThanOrEqualTo(0));
+        MatcherAssert.assertThat(value.compareTo(start), Matchers.greaterThanOrEqualTo(0));
       }
 
       if (end != null) {
         if (value == null) {
           Assert.assertNull("null values should be in first partition", start);
         } else {
-          Assert.assertThat(value.compareTo(end), Matchers.lessThan(0));
+          MatcherAssert.assertThat(value.compareTo(end), Matchers.lessThan(0));
         }
       }
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/StringSketchTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/StringSketchTest.java
@@ -27,6 +27,7 @@ import org.apache.druid.jackson.JacksonModule;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.timeline.partition.PartitionBoundaries;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.number.IsCloseTo;
 import org.junit.Assert;
@@ -208,12 +209,12 @@ public class StringSketchTest
         String partitionBoundariesString = PartitionTest.toString(partitionBoundaries);
         int expectedHighPartitionBoundaryCount = (int) Math.ceil((double) NUM_STRING / targetSize);
         int expectedLowPartitionBoundaryCount = expectedHighPartitionBoundaryCount - 1;
-        Assert.assertThat(
+        MatcherAssert.assertThat(
             "targetSize=" + targetSize + " " + partitionBoundariesString,
             partitionBoundaries.size(),
             Matchers.lessThanOrEqualTo(expectedHighPartitionBoundaryCount + 1)
         );
-        Assert.assertThat(
+        MatcherAssert.assertThat(
             "targetSize=" + targetSize + " " + partitionBoundariesString,
             partitionBoundaries.size(),
             Matchers.greaterThanOrEqualTo(expectedLowPartitionBoundaryCount + 1)
@@ -223,7 +224,7 @@ public class StringSketchTest
         for (int i = 1; i < partitionBoundaries.size() - 1; i++) {
           int current = Integer.parseInt(partitionBoundaries.get(i).get(0));
           int size = current - previous;
-          Assert.assertThat(
+          MatcherAssert.assertThat(
               getErrMsgPrefix(targetSize, i) + partitionBoundariesString,
               (double) size,
               IsCloseTo.closeTo(targetSize, Math.ceil(DELTA) * 2)
@@ -314,12 +315,12 @@ public class StringSketchTest
         for (int i = 1; i < partitionBoundaries.size() - 1; i++) {
           int current = Integer.parseInt(partitionBoundaries.get(i).get(0));
           int size = current - previous;
-          Assert.assertThat(
+          MatcherAssert.assertThat(
               getErrMsgPrefix(maxSize, i) + partitionBoundariesString,
               size,
               Matchers.lessThanOrEqualTo(maxSize)
           );
-          Assert.assertThat(
+          MatcherAssert.assertThat(
               getErrMsgPrefix(maxSize, i) + partitionBoundariesString,
               (double) size,
               Matchers.greaterThanOrEqualTo(minSize)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/RangePartitionIndexTaskInputRowIteratorBuilderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/RangePartitionIndexTaskInputRowIteratorBuilderTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexing.common.task.batch.parallel.iterator;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.indexer.granularity.GranularitySpec;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.junit.Assert;
@@ -200,6 +201,6 @@ public class RangePartitionIndexTaskInputRowIteratorBuilderTest
       IndexTaskInputRowIteratorBuilderTestingFactory.HandlerTester.Handler handler
   )
   {
-    Assert.assertThat(handlerInvocationHistory, Matchers.not(Matchers.contains(handler)));
+    MatcherAssert.assertThat(handlerInvocationHistory, Matchers.not(Matchers.contains(handler)));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidInputSourceTest.java
@@ -39,6 +39,7 @@ import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.TestHelper;
 import org.easymock.EasyMock;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Before;
@@ -86,7 +87,7 @@ public class DruidInputSourceTest
 
     final InputSource inputSource = mapper.readValue(json, InputSource.class);
 
-    Assert.assertThat(inputSource, CoreMatchers.instanceOf(DruidInputSource.class));
+    MatcherAssert.assertThat(inputSource, CoreMatchers.instanceOf(DruidInputSource.class));
     Assert.assertEquals(
         new DruidInputSource(
             "foo",
@@ -119,7 +120,7 @@ public class DruidInputSourceTest
 
     final InputSource inputSource = mapper.readValue(json, InputSource.class);
 
-    Assert.assertThat(inputSource, CoreMatchers.instanceOf(DruidInputSource.class));
+    MatcherAssert.assertThat(inputSource, CoreMatchers.instanceOf(DruidInputSource.class));
     Assert.assertEquals(
         new DruidInputSource(
             "foo",
@@ -153,7 +154,7 @@ public class DruidInputSourceTest
 
     final InputSource inputSource = mapper.readValue(json, InputSource.class);
 
-    Assert.assertThat(inputSource, CoreMatchers.instanceOf(DruidInputSource.class));
+    MatcherAssert.assertThat(inputSource, CoreMatchers.instanceOf(DruidInputSource.class));
     Assert.assertEquals(
         new DruidInputSource(
             "foo",

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunnerTest.java
@@ -64,6 +64,7 @@ import org.apache.druid.server.security.AuthTestUtils;
 import org.apache.druid.utils.JvmUtils;
 import org.easymock.EasyMock;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -181,7 +182,7 @@ public class SingleTaskBackgroundRunnerTest
             .build()
             .getRunner(runner);
 
-    Assert.assertThat(queryRunner, CoreMatchers.instanceOf(SetAndVerifyContextQueryRunner.class));
+    MatcherAssert.assertThat(queryRunner, CoreMatchers.instanceOf(SetAndVerifyContextQueryRunner.class));
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentTest.java
@@ -40,6 +40,7 @@ import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -248,7 +249,7 @@ public class HashJoinSegmentTest extends InitializedNullHandlingTest
   @Test
   public void test_asCursorFactory()
   {
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         makeJoinSegment().as(CursorFactory.class),
         CoreMatchers.instanceOf(HashJoinSegmentCursorFactory.class)
     );

--- a/processing/src/test/java/org/apache/druid/utils/CloseableUtilsTest.java
+++ b/processing/src/test/java/org/apache/druid/utils/CloseableUtilsTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.utils;
 
 import com.google.common.base.Throwables;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.internal.matchers.ThrowableCauseMatcher;
@@ -75,11 +76,11 @@ public class CloseableUtilsTest
     assertClosed(quietCloseable, ioExceptionCloseable, quietCloseable2, runtimeExceptionCloseable);
 
     // First exception
-    Assert.assertThat(e, CoreMatchers.instanceOf(IOException.class));
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(IOException.class));
 
     // Second exception
     Assert.assertEquals(1, e.getSuppressed().length);
-    Assert.assertThat(e.getSuppressed()[0], CoreMatchers.instanceOf(IllegalArgumentException.class));
+    MatcherAssert.assertThat(e.getSuppressed()[0], CoreMatchers.instanceOf(IllegalArgumentException.class));
   }
 
   @Test
@@ -104,11 +105,11 @@ public class CloseableUtilsTest
     assertClosed(quietCloseable, ioExceptionCloseable, quietCloseable2, runtimeExceptionCloseable);
 
     // First exception
-    Assert.assertThat(e, CoreMatchers.instanceOf(IOException.class));
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(IOException.class));
 
     // Second exception
     Assert.assertEquals(1, e.getSuppressed().length);
-    Assert.assertThat(e.getSuppressed()[0], CoreMatchers.instanceOf(IllegalArgumentException.class));
+    MatcherAssert.assertThat(e.getSuppressed()[0], CoreMatchers.instanceOf(IllegalArgumentException.class));
   }
 
   @Test
@@ -137,7 +138,7 @@ public class CloseableUtilsTest
     }
 
     assertClosed(ioExceptionCloseable);
-    Assert.assertThat(e, CoreMatchers.instanceOf(RuntimeException.class));
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(RuntimeException.class));
   }
 
   @Test
@@ -152,7 +153,7 @@ public class CloseableUtilsTest
     }
 
     assertClosed(runtimeExceptionCloseable);
-    Assert.assertThat(e, CoreMatchers.instanceOf(IllegalArgumentException.class));
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(IllegalArgumentException.class));
   }
 
   @Test
@@ -167,7 +168,7 @@ public class CloseableUtilsTest
     }
 
     assertClosed(assertionErrorCloseable);
-    Assert.assertThat(e, CoreMatchers.instanceOf(AssertionError.class));
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(AssertionError.class));
   }
 
   @Test
@@ -223,8 +224,8 @@ public class CloseableUtilsTest
 
     Assert.assertTrue(quietCloseable.isClosed());
 
-    Assert.assertThat(e, CoreMatchers.instanceOf(IllegalStateException.class));
-    Assert.assertThat(
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(IllegalStateException.class));
+    MatcherAssert.assertThat(
         e,
         ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Must be called with non-null caught exception"))
     );
@@ -244,8 +245,8 @@ public class CloseableUtilsTest
 
     Assert.assertTrue(quietCloseable.isClosed());
 
-    Assert.assertThat(e, CoreMatchers.instanceOf(RuntimeException.class));
-    Assert.assertThat(
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(RuntimeException.class));
+    MatcherAssert.assertThat(
         e,
         ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("this one was caught"))
     );
@@ -266,15 +267,15 @@ public class CloseableUtilsTest
     Assert.assertTrue(ioExceptionCloseable.isClosed());
 
     // First exception
-    Assert.assertThat(e, CoreMatchers.instanceOf(IOException.class));
-    Assert.assertThat(
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(IOException.class));
+    MatcherAssert.assertThat(
         e,
         ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("this one was caught"))
     );
 
     // Second exception
     Assert.assertEquals(1, e.getSuppressed().length);
-    Assert.assertThat(e.getSuppressed()[0], CoreMatchers.instanceOf(IOException.class));
+    MatcherAssert.assertThat(e.getSuppressed()[0], CoreMatchers.instanceOf(IOException.class));
   }
 
   @Test
@@ -292,15 +293,15 @@ public class CloseableUtilsTest
     Assert.assertTrue(runtimeExceptionCloseable.isClosed());
 
     // First exception
-    Assert.assertThat(e, CoreMatchers.instanceOf(RuntimeException.class));
-    Assert.assertThat(
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(RuntimeException.class));
+    MatcherAssert.assertThat(
         e,
         ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("this one was caught"))
     );
 
     // Second exception
     Assert.assertEquals(1, e.getSuppressed().length);
-    Assert.assertThat(e.getSuppressed()[0], CoreMatchers.instanceOf(IllegalArgumentException.class));
+    MatcherAssert.assertThat(e.getSuppressed()[0], CoreMatchers.instanceOf(IllegalArgumentException.class));
   }
 
   @Test
@@ -317,8 +318,8 @@ public class CloseableUtilsTest
 
     Assert.assertTrue(quietCloseable.isClosed());
 
-    Assert.assertThat(e, CoreMatchers.instanceOf(IllegalStateException.class));
-    Assert.assertThat(
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(IllegalStateException.class));
+    MatcherAssert.assertThat(
         e,
         ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Must be called with non-null caught exception"))
     );
@@ -338,8 +339,8 @@ public class CloseableUtilsTest
 
     Assert.assertTrue(quietCloseable.isClosed());
 
-    Assert.assertThat(e, CoreMatchers.instanceOf(RuntimeException.class));
-    Assert.assertThat(
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(RuntimeException.class));
+    MatcherAssert.assertThat(
         e,
         ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("this one was caught"))
     );
@@ -360,13 +361,13 @@ public class CloseableUtilsTest
     Assert.assertTrue(ioExceptionCloseable.isClosed());
 
     // First exception
-    Assert.assertThat(e, CoreMatchers.instanceOf(RuntimeException.class));
-    Assert.assertThat(
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(RuntimeException.class));
+    MatcherAssert.assertThat(
         e,
         ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("java.io.IOException: this one was caught"))
     );
-    Assert.assertThat(e, ThrowableCauseMatcher.hasCause(CoreMatchers.instanceOf(IOException.class)));
-    Assert.assertThat(
+    MatcherAssert.assertThat(e, ThrowableCauseMatcher.hasCause(CoreMatchers.instanceOf(IOException.class)));
+    MatcherAssert.assertThat(
         e,
         ThrowableCauseMatcher.hasCause(
             ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("this one was caught"))
@@ -375,7 +376,7 @@ public class CloseableUtilsTest
 
     // Second exception
     Assert.assertEquals(1, e.getCause().getSuppressed().length);
-    Assert.assertThat(e.getCause().getSuppressed()[0], CoreMatchers.instanceOf(IOException.class));
+    MatcherAssert.assertThat(e.getCause().getSuppressed()[0], CoreMatchers.instanceOf(IOException.class));
   }
 
   @Test
@@ -393,15 +394,15 @@ public class CloseableUtilsTest
     Assert.assertTrue(runtimeExceptionCloseable.isClosed());
 
     // First exception
-    Assert.assertThat(e, CoreMatchers.instanceOf(RuntimeException.class));
-    Assert.assertThat(
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(RuntimeException.class));
+    MatcherAssert.assertThat(
         e,
         ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("this one was caught"))
     );
 
     // Second exception
     Assert.assertEquals(1, e.getSuppressed().length);
-    Assert.assertThat(e.getSuppressed()[0], CoreMatchers.instanceOf(IllegalArgumentException.class));
+    MatcherAssert.assertThat(e.getSuppressed()[0], CoreMatchers.instanceOf(IllegalArgumentException.class));
   }
 
   @Test
@@ -419,15 +420,15 @@ public class CloseableUtilsTest
     Assert.assertTrue(assertionErrorCloseable.isClosed());
 
     // First exception
-    Assert.assertThat(e, CoreMatchers.instanceOf(RuntimeException.class));
-    Assert.assertThat(
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(RuntimeException.class));
+    MatcherAssert.assertThat(
         e,
         ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("this one was caught"))
     );
 
     // Second exception
     Assert.assertEquals(1, e.getSuppressed().length);
-    Assert.assertThat(e.getSuppressed()[0], CoreMatchers.instanceOf(AssertionError.class));
+    MatcherAssert.assertThat(e.getSuppressed()[0], CoreMatchers.instanceOf(AssertionError.class));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/curator/CuratorModuleTest.java
+++ b/server/src/test/java/org/apache/druid/curator/CuratorModuleTest.java
@@ -135,7 +135,7 @@ public final class CuratorModuleTest
   {
     CuratorFramework curatorFramework = injector.getInstance(CuratorFramework.class);
     RetryPolicy retryPolicy = curatorFramework.getZookeeperClient().getRetryPolicy();
-    Assert.assertThat(retryPolicy, CoreMatchers.instanceOf(ExponentialBackoffRetry.class));
+    MatcherAssert.assertThat(retryPolicy, CoreMatchers.instanceOf(ExponentialBackoffRetry.class));
     RetryPolicy adjustedRetryPolicy = adjustRetryPolicy((BoundedExponentialBackoffRetry) retryPolicy, maxRetries);
     curatorFramework.getZookeeperClient().setRetryPolicy(adjustedRetryPolicy);
     return curatorFramework;

--- a/server/src/test/java/org/apache/druid/segment/InlineSegmentWranglerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/InlineSegmentWranglerTest.java
@@ -27,6 +27,7 @@ import org.apache.druid.query.TableDataSource;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -74,6 +75,6 @@ public class InlineSegmentWranglerTest
     Assert.assertEquals(1, segments.size());
 
     final Segment segment = Iterables.getOnlyElement(segments);
-    Assert.assertThat(segment, CoreMatchers.instanceOf(RowBasedSegment.class));
+    MatcherAssert.assertThat(segment, CoreMatchers.instanceOf(RowBasedSegment.class));
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/LookupSegmentWranglerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/LookupSegmentWranglerTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.lookup.LookupSegment;
 import org.apache.druid.query.lookup.LookupSegmentTest;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -99,7 +100,7 @@ public class LookupSegmentWranglerTest
     );
 
     Assert.assertEquals(1, segments.size());
-    Assert.assertThat(Iterables.getOnlyElement(segments), CoreMatchers.instanceOf(LookupSegment.class));
+    MatcherAssert.assertThat(Iterables.getOnlyElement(segments), CoreMatchers.instanceOf(LookupSegment.class));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/segment/join/LookupJoinableFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/segment/join/LookupJoinableFactoryTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.lookup.MapLookupExtractorFactory;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -125,7 +126,7 @@ public class LookupJoinableFactoryTest
   {
     final Joinable joinable = factory.build(lookupDataSource, makeCondition("x == \"j.k\"")).get();
 
-    Assert.assertThat(joinable, CoreMatchers.instanceOf(LookupJoinable.class));
+    MatcherAssert.assertThat(joinable, CoreMatchers.instanceOf(LookupJoinable.class));
     Assert.assertEquals(ImmutableList.of("k", "v"), joinable.getAvailableColumns());
     Assert.assertEquals(Joinable.CARDINALITY_UNKNOWN, joinable.getCardinality("k"));
     Assert.assertEquals(Joinable.CARDINALITY_UNKNOWN, joinable.getCardinality("v"));

--- a/server/src/test/java/org/apache/druid/server/emitter/EmitterModuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/emitter/EmitterModuleTest.java
@@ -54,6 +54,7 @@ import org.apache.druid.server.metrics.DefaultLoadSpecHolder;
 import org.apache.druid.server.metrics.LoadSpecHolder;
 import org.apache.druid.server.metrics.TestTaskHolder;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -85,7 +86,7 @@ public class EmitterModuleTest
     final Emitter emitter = makeInjectorWithProperties(props).getInstance(Emitter.class);
 
     // Testing that ParametrizedUriEmitter is successfully deserialized from the above config
-    Assert.assertThat(emitter, CoreMatchers.instanceOf(ParametrizedUriEmitter.class));
+    MatcherAssert.assertThat(emitter, CoreMatchers.instanceOf(ParametrizedUriEmitter.class));
   }
 
   @Test
@@ -95,7 +96,7 @@ public class EmitterModuleTest
     props.setProperty("druid.emitter", "");
 
     final Emitter emitter = makeInjectorWithProperties(props).getInstance(Emitter.class);
-    Assert.assertThat(emitter, CoreMatchers.instanceOf(NoopEmitter.class));
+    MatcherAssert.assertThat(emitter, CoreMatchers.instanceOf(NoopEmitter.class));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/log/LoggingRequestLoggerProviderTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/LoggingRequestLoggerProviderTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.guice.JsonConfigurator;
 import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.guice.QueryableModule;
 import org.apache.druid.initialization.Initialization;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
@@ -77,7 +78,7 @@ public class LoggingRequestLoggerProviderTest
     final Properties properties = new Properties();
     properties.put(propertyPrefix + ".type", "noop");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
-    Assert.assertThat(provider.get().get(), Matchers.instanceOf(NoopRequestLogger.class));
+    MatcherAssert.assertThat(provider.get().get(), Matchers.instanceOf(NoopRequestLogger.class));
   }
 
   private Injector makeInjector()

--- a/server/src/test/java/org/apache/druid/server/log/RequestLoggerProviderTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/RequestLoggerProviderTest.java
@@ -25,7 +25,7 @@ import com.google.inject.ProvisionException;
 import org.apache.druid.guice.JsonConfigurator;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
+import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -69,7 +69,7 @@ public class RequestLoggerProviderTest
         RequestLoggerProvider.class,
         NoopRequestLoggerProvider.class
     );
-    Assert.assertThat(provider, CoreMatchers.instanceOf(NoopRequestLoggerProvider.class));
+    MatcherAssert.assertThat(provider, CoreMatchers.instanceOf(NoopRequestLoggerProvider.class));
   }
 
   @Test


### PR DESCRIPTION
Created by the GPT-5.6-Sol model.

## Summary

- Replace all 79 deprecated `org.junit.Assert.assertThat` invocations with `org.hamcrest.MatcherAssert.assertThat`.
- Add both deprecated JUnit overloads to Druid's Maven Forbidden APIs signatures.
- Keep assertion behavior unchanged while preventing new uses from compiling.

## Why

CodeQL currently reports 79 deprecated-call notes for JUnit's `Assert.assertThat`. Hamcrest owns these assertions directly, and JUnit 4.13 deprecates its forwarding overloads.

## Impact

The source changes are test-only. The Maven Forbidden APIs check now fails if either JUnit `assertThat` overload is introduced in main or test bytecode.

## Root cause

These tests retained JUnit's legacy Hamcrest forwarding API after the assertion implementation moved to Hamcrest.

## Checks

- `mvn -ntp -B test-compile -Dweb.console.skip=true -DskipTests -T1C`
  - all 78 reactor modules passed
  - Checkstyle, PMD, Enforcer, compilation, and Forbidden APIs checks passed
- `git diff --check`
