### PR TITLE
fix(test): wait for Kafka topic leaders after creation

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.CreatePartitionsResult;
 import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -134,6 +135,15 @@ public class KafkaResource extends StreamIngestResource<KafkaContainer>
       admin.createTopics(
           List.of(new NewTopic(topicName, numPartitions, (short) 1))
       ).all().get();
+
+      // createTopics() may complete before the partition leaders are ready to
+      // handle requests. Verify every partition through its leader before
+      // allowing callers to start a supervisor or publish records.
+      final Map<TopicPartition, OffsetSpec> partitionOffsets = new HashMap<>();
+      for (int partition = 0; partition < numPartitions; partition++) {
+        partitionOffsets.put(new TopicPartition(topicName, partition), OffsetSpec.latest());
+      }
+      admin.listOffsets(partitionOffsets).all().get();
     }
     catch (Exception e) {
       throw new RuntimeException(e);

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResourceTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResourceTest.java
@@ -23,6 +23,7 @@ import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -60,6 +61,16 @@ public class KafkaResourceTest
     final String topicName = "test-topic";
     resource.createTopicWithPartitions(topicName, 3);
     assertEquals(Set.of(topicName), resource.listTopics());
+
+    // Verify that callers can publish immediately after topic creation.
+    resource.publishRecordsToTopicWithoutTransaction(
+        topicName,
+        Collections.nCopies(1_000, new byte[]{1})
+    );
+    final Map<String, Long> partitionOffsets = resource.getPartitionOffsets(topicName);
+    assertEquals(3, partitionOffsets.size());
+    assertEquals(1_000, partitionOffsets.values().stream().mapToLong(Long::longValue).sum());
+
     resource.deleteTopic(topicName);
 
     resource.stop();


### PR DESCRIPTION
### Description

This fixes the embedded Kafka startup race exposed by
`KafkaIndexFaultToleranceTest.test_supervisorRecords_afterHistoricalRestart` in #19808.

`Admin.createTopics(...).all().get()` confirms that the topic metadata operation completed, but it does not guarantee
that every partition leader is already ready to serve requests. `StreamIndexFaultToleranceTest` creates a topic and
immediately starts its supervisor and publishes records. If the initial partition leaders are still becoming
available, the first batch can fail to reach Kafka and the test waits for an `ingest/rows/published` event that never
arrives.

This PR:

- verifies a latest-offset lookup through every initial partition leader before `createTopicWithPartitions` returns;
- adds regression coverage that publishes 1,000 non-transactional records immediately after topic creation and
  verifies all records reached the three partitions.

This complements #19817: that PR covers readiness after increasing an existing topic's partition count and surfaces
asynchronous producer failures; this PR covers readiness immediately after initial topic creation.

There is no end-user behavior change. The affected helper is used only by embedded tests.

### Tests

- `KafkaResourceTest` passed with the immediate non-transactional publish regression.
- `KafkaIndexFaultToleranceTest#test_supervisorRecords_afterHistoricalRestart` passed twice in focused embedded-test
  reactor runs.
- `git diff --check` passed.

Created by GPT-5.6-Sol.
