### PR TITLE
fix: remove redundant Python assignments

### DIFF
--- a/distribution/bin/jar-notice-lister.py
+++ b/distribution/bin/jar-notice-lister.py
@@ -75,10 +75,10 @@ def get_notices(tmp_jar_path):
         for line in outstr.splitlines():
             try:
                 command = "jar xf {} {}".format(jar_file, line)
-                outstr = subprocess.check_output(command, shell=True).decode('UTF-8')
+                subprocess.check_output(command, shell=True)
 
                 command = "mv {} {}.NOTICE-FILE".format(line, jar_file)
-                outstr = subprocess.check_output(command, shell=True).decode('UTF-8')
+                subprocess.check_output(command, shell=True)
 
                 command = "cat {}.NOTICE-FILE".format(jar_file)
                 outstr = subprocess.check_output(command, shell=True).decode('UTF-8')

--- a/examples/bin/start-druid-main.py
+++ b/examples/bin/start-druid-main.py
@@ -529,7 +529,7 @@ def distribute_memory(services, total_memory):
         if service in MINIMUM_MEMORY_MB and allocated_memory < MINIMUM_MEMORY_MB.get(service):
             allocated_memory = MINIMUM_MEMORY_MB.get(service)
 
-        service_memory_config[service], allocated_memory = build_memory_config(service, allocated_memory)
+        service_memory_config[service] = build_memory_config(service, allocated_memory)[0]
 
     print_if_verbose('\nMemory distribution for services:')
     for key, value in service_memory_config.items():


### PR DESCRIPTION
Created by GPT-5.6-Sol.

## Summary

- keep only the memory configuration returned for services whose adjusted allocation is not reused
- discard the intentionally unused output of jar extraction and move commands instead of repeatedly redefining the NOTICE output variable
- add the required trailing newline to the NOTICE helper

This directly addresses all three py/multiple-definition CodeQL warnings without changing command execution or output behavior.

## Validation

- both modified scripts compile with Python 3 py_compile
- git diff --check passed