### PR TITLE
feat: Add CONTAINERSIZE segment metadata analysis type

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/DruidSchemaInternRowSignatureBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/DruidSchemaInternRowSignatureBenchmark.java
@@ -134,18 +134,13 @@ public class DruidSchemaInternRowSignatureBenchmark
       return Sequences.simple(
           Lists.transform(
               Lists.newArrayList(segments),
-              (segment) -> new SegmentAnalysis(
-                  segment.toString(),
-                  ImmutableList.of(segment.getInterval()),
-                  columnToAnalysisMap,
-                  40,
-                  40,
-                  null,
-                  null,
-                  null,
-                  null,
-                  false
-              )
+              (segment) -> new SegmentAnalysis.Builder(segment)
+                  .interval(segment.getInterval())
+                  .columns(columnToAnalysisMap)
+                  .size(40)
+                  .numRows(40)
+                  .rollup(false)
+                  .build()
           )
       );
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -126,6 +126,7 @@ import org.apache.druid.segment.data.CompressionFactory.LongEncodingStrategy;
 import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.data.ListIndexed;
 import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
+import org.apache.druid.segment.file.NoopSegmentFileMapper;
 import org.apache.druid.segment.incremental.RowIngestionMetersFactory;
 import org.apache.druid.segment.indexing.BatchIOConfig;
 import org.apache.druid.segment.indexing.CombinedDataSchema;
@@ -2354,7 +2355,7 @@ public class CompactionTaskTest
                 new ListIndexed<>(segment.getDimensions()),
                 null,
                 columnMap,
-                null
+                NoopSegmentFileMapper.INSTANCE
             )
             {
               @Override

--- a/processing/src/main/java/org/apache/druid/java/util/common/io/smoosh/SmooshedFileMapper.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/io/smoosh/SmooshedFileMapper.java
@@ -27,7 +27,9 @@ import com.google.common.io.Files;
 import org.apache.druid.java.util.common.ByteBufferUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.segment.file.SegmentFileMapper;
+import org.apache.druid.segment.file.SegmentFileMetadata;
 
+import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -118,6 +120,14 @@ public class SmooshedFileMapper implements SegmentFileMapper
   public Set<String> getInternalFilenames()
   {
     return internalFiles.keySet();
+  }
+
+  @Nullable
+  @Override
+  public SegmentFileMetadata getSegmentFileMetadata()
+  {
+    // legacy smoosh files have no container/bundle structure to report.
+    return null;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -55,6 +55,7 @@ import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.query.metadata.metadata.AggregatorMergeStrategy;
 import org.apache.druid.query.metadata.metadata.ColumnAnalysis;
 import org.apache.druid.query.metadata.metadata.SegmentAnalysis;
+import org.apache.druid.query.metadata.metadata.SegmentAnalysis.ContainerAnalysis;
 import org.apache.druid.query.metadata.metadata.SegmentMetadataQuery;
 import org.apache.druid.segment.AggregateProjectionMetadata;
 import org.apache.druid.timeline.LogicalSegment;
@@ -457,35 +458,71 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
       projections = null;
     }
 
-    return new SegmentAnalysis(
-        mergedId,
-        newIntervals,
-        columns,
-        arg1.getSize() + arg2.getSize(),
-        arg1.getNumRows() + arg2.getNumRows(),
-        aggregators.isEmpty() ? null : aggregators,
-        (projections == null || projections.isEmpty()) ? null : projections,
-        timestampSpec,
-        queryGranularity,
-        rollup
-    );
+    // Merged containers report one total per bundle name rather than a raw list of every underlying segment's
+    // individual containers, since a container has no identity across segments (only bundle names do).
+    final List<ContainerAnalysis> containers = mergeContainers(arg1.getContainers(), arg2.getContainers());
+
+    return new SegmentAnalysis.Builder(mergedId)
+        .intervals(newIntervals)
+        .columns(columns)
+        .size(arg1.getSize() + arg2.getSize())
+        .numRows(arg1.getNumRows() + arg2.getNumRows())
+        .aggregators(aggregators)
+        .projections(projections)
+        .timestampSpec(timestampSpec)
+        .queryGranularity(queryGranularity)
+        .rollup(rollup)
+        .containers(containers)
+        .build();
+  }
+
+  /**
+   * Sum container sizes by bundle name across two segments' container lists. A container has no identity across
+   * segments (which internal files land in which container is an incidental per-segment packing detail), so unlike
+   * a within-segment container list, the merged result isn't "the containers" of any single segment — it's a
+   * per-bundle total. When only one side has data, that side is returned unchanged rather than run through the
+   * per-bundle collapse: there's nothing to merge it with, and a single segment's own container list may
+   * legitimately have more than one entry for the same bundle (a bundle spanning multiple containers), which this
+   * method should not silently collapse when it isn't actually merging anything.
+   */
+  @Nullable
+  private static List<ContainerAnalysis> mergeContainers(
+      @Nullable List<ContainerAnalysis> containers1,
+      @Nullable List<ContainerAnalysis> containers2
+  )
+  {
+    if (containers1 == null) {
+      return containers2;
+    }
+    if (containers2 == null) {
+      return containers1;
+    }
+    final Map<String, Long> sizeByBundle = new LinkedHashMap<>();
+    for (ContainerAnalysis container : Iterables.concat(containers1, containers2)) {
+      sizeByBundle.merge(container.bundle(), container.size(), Long::sum);
+    }
+    final List<ContainerAnalysis> merged = new ArrayList<>(sizeByBundle.size());
+    for (Map.Entry<String, Long> entry : sizeByBundle.entrySet()) {
+      merged.add(new ContainerAnalysis(entry.getKey(), entry.getValue()));
+    }
+    return merged;
   }
 
   @VisibleForTesting
   public static SegmentAnalysis finalizeAnalysis(SegmentAnalysis analysis)
   {
-    return new SegmentAnalysis(
-        analysis.getId(),
-        analysis.getIntervals() != null ? JodaUtils.condenseIntervals(analysis.getIntervals()) : null,
-        analysis.getColumns(),
-        analysis.getSize(),
-        analysis.getNumRows(),
-        analysis.getAggregators(),
-        analysis.getProjections(),
-        analysis.getTimestampSpec(),
-        analysis.getQueryGranularity(),
-        analysis.isRollup()
-    );
+    return new SegmentAnalysis.Builder(analysis.getId())
+        .intervals(analysis.getIntervals() != null ? JodaUtils.condenseIntervals(analysis.getIntervals()) : null)
+        .columns(analysis.getColumns())
+        .size(analysis.getSize())
+        .numRows(analysis.getNumRows())
+        .aggregators(analysis.getAggregators())
+        .projections(analysis.getProjections())
+        .timestampSpec(analysis.getTimestampSpec())
+        .queryGranularity(analysis.getQueryGranularity())
+        .rollup(analysis.isRollup())
+        .containers(analysis.getContainers())
+        .build();
   }
 
   public SegmentMetadataQueryConfig getConfig()

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -477,13 +477,10 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
   }
 
   /**
-   * Sum container sizes by bundle name across two segments' container lists. A container has no identity across
-   * segments (which internal files land in which container is an incidental per-segment packing detail), so unlike
-   * a within-segment container list, the merged result isn't "the containers" of any single segment — it's a
-   * per-bundle total. When only one side has data, that side is returned unchanged rather than run through the
-   * per-bundle collapse: there's nothing to merge it with, and a single segment's own container list may
-   * legitimately have more than one entry for the same bundle (a bundle spanning multiple containers), which this
-   * method should not silently collapse when it isn't actually merging anything.
+   * Sums container sizes by bundle name, since a container has no identity across segments. If only one side has
+   * data, it's returned unchanged instead of being run through the per-bundle collapse: there's nothing to merge it
+   * with, and a single segment's own list may already have more than one entry for the same bundle (a bundle
+   * spanning multiple containers).
    */
   @Nullable
   private static List<ContainerAnalysis> mergeContainers(

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
@@ -36,10 +36,13 @@ import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.query.metadata.metadata.ColumnAnalysis;
 import org.apache.druid.query.metadata.metadata.ColumnIncluderator;
 import org.apache.druid.query.metadata.metadata.SegmentAnalysis;
+import org.apache.druid.query.metadata.metadata.SegmentAnalysis.ContainerAnalysis;
 import org.apache.druid.query.metadata.metadata.SegmentMetadataQuery;
 import org.apache.druid.segment.AggregateProjectionMetadata;
 import org.apache.druid.segment.Metadata;
+import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.file.SegmentFileContainerMetadata;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
@@ -165,22 +168,33 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
           }
         }
 
-        return Sequences.simple(
-            Collections.singletonList(
-                new SegmentAnalysis(
-                    segment.getId().toString(),
-                    retIntervals,
-                    columns,
-                    totalSize,
-                    numRows,
-                    aggregators,
-                    projectionsMap,
-                    timestampSpec,
-                    queryGranularity,
-                    rollup
-                )
-            )
-        );
+        final List<ContainerAnalysis> containers;
+        if (updatedQuery.hasContainerSizes()) {
+          final QueryableIndex index = segment.as(QueryableIndex.class);
+          final List<SegmentFileContainerMetadata> fileContainers = index == null ? null : index.getFileContainers();
+          containers = fileContainers == null
+                       ? null
+                       : fileContainers.stream()
+                                       .map(c -> new ContainerAnalysis(c.getBundle(), c.getSize()))
+                                       .collect(Collectors.toList());
+        } else {
+          containers = null;
+        }
+
+        final SegmentAnalysis analysis = new SegmentAnalysis.Builder(segment.getId().toString())
+            .intervals(retIntervals)
+            .columns(columns)
+            .size(totalSize)
+            .numRows(numRows)
+            .aggregators(aggregators)
+            .projections(projectionsMap)
+            .timestampSpec(timestampSpec)
+            .queryGranularity(queryGranularity)
+            .rollup(rollup)
+            .containers(containers)
+            .build();
+
+        return Sequences.simple(Collections.singletonList(analysis));
       }
     };
   }

--- a/processing/src/main/java/org/apache/druid/query/metadata/metadata/SegmentAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/metadata/SegmentAnalysis.java
@@ -28,6 +28,7 @@ import org.apache.druid.segment.AggregateProjectionMetadata;
 import org.apache.druid.timeline.SegmentId;
 import org.joda.time.Interval;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -60,9 +61,10 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
   private final TimestampSpec timestampSpec;
   private final Granularity queryGranularity;
   private final Boolean rollup;
+  private final List<ContainerAnalysis> containers;
 
   @JsonCreator
-  public SegmentAnalysis(
+  SegmentAnalysis(
       @JsonProperty("id") String id,
       @JsonProperty("intervals") List<Interval> interval,
       @JsonProperty("columns") LinkedHashMap<String, ColumnAnalysis> columns,
@@ -72,7 +74,8 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
       @JsonProperty("projections") Map<String, AggregateProjectionMetadata> projections,
       @JsonProperty("timestampSpec") TimestampSpec timestampSpec,
       @JsonProperty("queryGranularity") Granularity queryGranularity,
-      @JsonProperty("rollup") Boolean rollup
+      @JsonProperty("rollup") Boolean rollup,
+      @JsonProperty("containers") List<ContainerAnalysis> containers
   )
   {
     this.id = id;
@@ -85,6 +88,7 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
     this.timestampSpec = timestampSpec;
     this.queryGranularity = queryGranularity;
     this.rollup = rollup;
+    this.containers = containers;
   }
 
   @JsonProperty
@@ -147,6 +151,12 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
     return projections;
   }
 
+  @JsonProperty
+  public List<ContainerAnalysis> getContainers()
+  {
+    return containers;
+  }
+
   @Override
   public String toString()
   {
@@ -161,6 +171,7 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
            ", timestampSpec=" + timestampSpec +
            ", queryGranularity=" + queryGranularity +
            ", rollup=" + rollup +
+           ", containers=" + containers +
            '}';
   }
 
@@ -186,7 +197,8 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
            Objects.equals(aggregators, that.aggregators) &&
            Objects.equals(projections, that.projections) &&
            Objects.equals(timestampSpec, that.timestampSpec) &&
-           Objects.equals(queryGranularity, that.queryGranularity);
+           Objects.equals(queryGranularity, that.queryGranularity) &&
+           Objects.equals(containers, that.containers);
   }
 
   /**
@@ -206,7 +218,8 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
         projections,
         timestampSpec,
         queryGranularity,
-        rollup
+        rollup,
+        containers
     );
   }
 
@@ -217,19 +230,26 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
   }
 
   /**
-   * Helper class to build {@link SegmentAnalysis} objects.
+   * Helper class to build {@link SegmentAnalysis} objects. Supports both incremental, single-entry building (handy
+   * for tests) and bulk setters that take an already-computed map/list (handy for production call sites that
+   * already have the whole thing on hand).
    */
   public static class Builder
   {
     private final String segmentId;
-    private final LinkedHashMap<String, ColumnAnalysis> columns = new LinkedHashMap<>();
-    private final Map<String, AggregatorFactory> aggregators = new LinkedHashMap<>();
-    private final Map<String, AggregateProjectionMetadata> projections = new LinkedHashMap<>();
+    private LinkedHashMap<String, ColumnAnalysis> columns = new LinkedHashMap<>();
+    private Map<String, AggregatorFactory> aggregators = new LinkedHashMap<>();
+    private Map<String, AggregateProjectionMetadata> projections = new LinkedHashMap<>();
+    private List<ContainerAnalysis> containers = new ArrayList<>();
 
     private List<Interval> intervals = null;
-    private Optional<Integer> size = Optional.empty();
-    private Optional<Integer> numRows = Optional.empty();
+    private Optional<Long> size = Optional.empty();
+    private Optional<Long> numRows = Optional.empty();
     private Optional<Boolean> rollup = Optional.empty();
+    @Nullable
+    private TimestampSpec timestampSpec = null;
+    @Nullable
+    private Granularity queryGranularity = null;
 
     public Builder(String segmentId)
     {
@@ -241,7 +261,7 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
       this.segmentId = segmentId.toString();
     }
 
-    public Builder size(int size)
+    public Builder size(long size)
     {
       if (this.size.isEmpty()) {
         this.size = Optional.of(size);
@@ -251,7 +271,7 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
       return this;
     }
 
-    public Builder numRows(int numRows)
+    public Builder numRows(long numRows)
     {
       if (this.numRows.isEmpty()) {
         this.numRows = Optional.of(numRows);
@@ -261,8 +281,11 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
       return this;
     }
 
-    public Builder rollup(boolean rollup)
+    public Builder rollup(@Nullable Boolean rollup)
     {
+      if (rollup == null) {
+        return this;
+      }
       if (this.rollup.isEmpty()) {
         this.rollup = Optional.of(rollup);
       } else {
@@ -280,9 +303,21 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
       return this;
     }
 
+    public Builder intervals(@Nullable List<Interval> intervals)
+    {
+      this.intervals = intervals == null ? null : new ArrayList<>(intervals);
+      return this;
+    }
+
     public Builder column(String columnName, ColumnAnalysis columnAnalysis)
     {
       this.columns.put(columnName, columnAnalysis);
+      return this;
+    }
+
+    public Builder columns(@Nullable LinkedHashMap<String, ColumnAnalysis> columns)
+    {
+      this.columns = columns == null ? new LinkedHashMap<>() : new LinkedHashMap<>(columns);
       return this;
     }
 
@@ -292,9 +327,45 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
       return this;
     }
 
+    public Builder aggregators(@Nullable Map<String, AggregatorFactory> aggregators)
+    {
+      this.aggregators = aggregators == null ? new LinkedHashMap<>() : new LinkedHashMap<>(aggregators);
+      return this;
+    }
+
     public Builder projection(String name, AggregateProjectionMetadata projection)
     {
       this.projections.put(name, projection);
+      return this;
+    }
+
+    public Builder projections(@Nullable Map<String, AggregateProjectionMetadata> projections)
+    {
+      this.projections = projections == null ? new LinkedHashMap<>() : new LinkedHashMap<>(projections);
+      return this;
+    }
+
+    public Builder container(String bundle, long size)
+    {
+      this.containers.add(new ContainerAnalysis(bundle, size));
+      return this;
+    }
+
+    public Builder containers(@Nullable List<ContainerAnalysis> containers)
+    {
+      this.containers = containers == null ? new ArrayList<>() : new ArrayList<>(containers);
+      return this;
+    }
+
+    public Builder timestampSpec(@Nullable TimestampSpec timestampSpec)
+    {
+      this.timestampSpec = timestampSpec;
+      return this;
+    }
+
+    public Builder queryGranularity(@Nullable Granularity queryGranularity)
+    {
+      this.queryGranularity = queryGranularity;
       return this;
     }
 
@@ -304,14 +375,30 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
           segmentId,
           intervals,
           columns,
-          size.orElse(0),
-          numRows.orElse(0),
+          size.orElse(0L),
+          numRows.orElse(0L),
           aggregators.isEmpty() ? null : aggregators,
           projections.isEmpty() ? null : projections,
-          null,
-          null,
-          rollup.orElse(null)
+          timestampSpec,
+          queryGranularity,
+          rollup.orElse(null),
+          containers.isEmpty() ? null : containers
       );
     }
+  }
+
+  /**
+   * On-disk byte size of a single segment file container (a V10 file format bundle), reported by
+   * {@link SegmentMetadataQuery.AnalysisType#CONTAINERSIZE}. One entry per physical container; a bundle (e.g. a
+   * projection name) may have more than one container if its contents exceeded the writer's max container size.
+   *
+   * @param bundle owning bundle name (e.g. the base table or a projection's name)
+   * @param size   on-disk byte size of this container
+   */
+  public record ContainerAnalysis(
+      @JsonProperty("bundle") String bundle,
+      @JsonProperty("size") long size
+  )
+  {
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/metadata/metadata/SegmentAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/metadata/SegmentAnalysis.java
@@ -63,6 +63,27 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
   private final Boolean rollup;
   private final List<ContainerAnalysis> containers;
 
+  /**
+   * Retained for binary compatibility with code compiled against the pre-{@link ContainerAnalysis} constructor.
+   * New callers should use {@link Builder}.
+   */
+  @Deprecated
+  public SegmentAnalysis(
+      String id,
+      List<Interval> interval,
+      LinkedHashMap<String, ColumnAnalysis> columns,
+      long size,
+      long numRows,
+      Map<String, AggregatorFactory> aggregators,
+      Map<String, AggregateProjectionMetadata> projections,
+      TimestampSpec timestampSpec,
+      Granularity queryGranularity,
+      Boolean rollup
+  )
+  {
+    this(id, interval, columns, size, numRows, aggregators, projections, timestampSpec, queryGranularity, rollup, null);
+  }
+
   @JsonCreator
   SegmentAnalysis(
       @JsonProperty("id") String id,
@@ -271,6 +292,15 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
       return this;
     }
 
+    /**
+     * Retained for binary compatibility with code compiled against the pre-{@link ContainerAnalysis} signature.
+     */
+    @Deprecated
+    public Builder size(int size)
+    {
+      return size((long) size);
+    }
+
     public Builder numRows(long numRows)
     {
       if (this.numRows.isEmpty()) {
@@ -279,6 +309,15 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
         throw new IllegalStateException("NumRows is already set: " + this.numRows.get());
       }
       return this;
+    }
+
+    /**
+     * Retained for binary compatibility with code compiled against the pre-{@link ContainerAnalysis} signature.
+     */
+    @Deprecated
+    public Builder numRows(int numRows)
+    {
+      return numRows((long) numRows);
     }
 
     public Builder rollup(@Nullable Boolean rollup)
@@ -292,6 +331,15 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
         throw new IllegalStateException("Rollup is already set: " + this.rollup.get());
       }
       return this;
+    }
+
+    /**
+     * Retained for binary compatibility with code compiled against the pre-{@link ContainerAnalysis} signature.
+     */
+    @Deprecated
+    public Builder rollup(boolean rollup)
+    {
+      return rollup(Boolean.valueOf(rollup));
     }
 
     public Builder interval(Interval interval)

--- a/processing/src/main/java/org/apache/druid/query/metadata/metadata/SegmentMetadataQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/metadata/SegmentMetadataQuery.java
@@ -60,7 +60,13 @@ public class SegmentMetadataQuery extends BaseQuery<SegmentAnalysis>
     TIMESTAMPSPEC,
     QUERYGRANULARITY,
     ROLLUP,
-    PROJECTIONS;
+    PROJECTIONS,
+    /**
+     * Reports {@link SegmentAnalysis#getContainers()}: per-container on-disk byte sizes. Only populated for segments
+     * written in the V10 file format ({@code IndexMergerV10}); pre-V10 segments report {@code null} here, same as
+     * any other analysis type applied to a segment that predates it.
+     */
+    CONTAINERSIZE;
 
     @JsonValue
     @Override
@@ -196,6 +202,11 @@ public class SegmentMetadataQuery extends BaseQuery<SegmentAnalysis>
   public boolean hasProjections()
   {
     return analysisTypes.contains(AnalysisType.PROJECTIONS);
+  }
+
+  public boolean hasContainerSizes()
+  {
+    return analysisTypes.contains(AnalysisType.CONTAINERSIZE);
   }
 
   public boolean hasTimestampSpec()

--- a/processing/src/main/java/org/apache/druid/query/metadata/metadata/SegmentMetadataQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/metadata/SegmentMetadataQuery.java
@@ -64,7 +64,8 @@ public class SegmentMetadataQuery extends BaseQuery<SegmentAnalysis>
     /**
      * Reports {@link SegmentAnalysis#getContainers()}: per-container on-disk byte sizes. Only populated for segments
      * written in the V10 file format ({@code IndexMergerV10}); pre-V10 segments report {@code null} here, same as
-     * any other analysis type applied to a segment that predates it.
+     * any other analysis type applied to a segment that predates it. Only counts containers in the segment's
+     * entry-point file; a bundle whose data spilled into an attached external file is undercounted.
      */
     CONTAINERSIZE;
 

--- a/processing/src/main/java/org/apache/druid/segment/PartialQueryableIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/PartialQueryableIndex.java
@@ -299,6 +299,11 @@ public class PartialQueryableIndex implements QueryableIndex
     return ordering;
   }
 
+  /**
+   * Doesn't include containers from any external mapper {@link #fileMapper} may have attached (see
+   * {@link PartialSegmentFileMapperV10}) — those aren't reflected in {@link #metadata}, so a bundle whose data
+   * spilled into an external file will be undercounted here.
+   */
   @Nullable
   @Override
   public List<SegmentFileContainerMetadata> getFileContainers()

--- a/processing/src/main/java/org/apache/druid/segment/PartialQueryableIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/PartialQueryableIndex.java
@@ -40,6 +40,7 @@ import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.Indexed;
 import org.apache.druid.segment.data.ListIndexed;
 import org.apache.druid.segment.file.PartialSegmentFileMapperV10;
+import org.apache.druid.segment.file.SegmentFileContainerMetadata;
 import org.apache.druid.segment.file.SegmentFileMapper;
 import org.apache.druid.segment.file.SegmentFileMetadata;
 import org.apache.druid.segment.projections.AggregateProjectionSchema;
@@ -296,6 +297,13 @@ public class PartialQueryableIndex implements QueryableIndex
   public List<OrderBy> getOrdering()
   {
     return ordering;
+  }
+
+  @Nullable
+  @Override
+  public List<SegmentFileContainerMetadata> getFileContainers()
+  {
+    return metadata.getContainers();
   }
 
   @Nullable

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndex.java
@@ -152,7 +152,9 @@ public interface QueryableIndex extends Closeable, ColumnInspector
   /**
    * Returns the on-disk containers backing this index (V10 file format bundles), or {@code null} if unknown or
    * unsupported (e.g. legacy pre-V10 segments or in-memory indexes). Used by the {@code CONTAINERSIZE} segment
-   * metadata analysis type to report each container's owning bundle name and byte size.
+   * metadata analysis type to report each container's owning bundle name and byte size. Implementations only report
+   * containers from the entry-point segment file; a bundle whose data spilled into an attached external file is
+   * undercounted, since the external file's own containers aren't included.
    */
   @Nullable
   default List<SegmentFileContainerMetadata> getFileContainers()

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndex.java
@@ -25,6 +25,7 @@ import org.apache.druid.segment.column.BaseColumnHolder;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.data.Indexed;
+import org.apache.druid.segment.file.SegmentFileContainerMetadata;
 import org.apache.druid.segment.projections.ClusteredValueGroupsBaseTableSchema;
 import org.apache.druid.segment.projections.QueryableProjection;
 import org.apache.druid.segment.projections.TableClusterGroupSpec;
@@ -144,6 +145,17 @@ public interface QueryableIndex extends Closeable, ColumnInspector
    */
   @Nullable
   default QueryableIndex getClusterGroupQueryableIndex(TableClusterGroupSpec groupSpec, boolean withClusteringColumns)
+  {
+    return null;
+  }
+
+  /**
+   * Returns the on-disk containers backing this index (V10 file format bundles), or {@code null} if unknown or
+   * unsupported (e.g. legacy pre-V10 segments or in-memory indexes). Used by the {@code CONTAINERSIZE} segment
+   * metadata analysis type to report each container's owning bundle name and byte size.
+   */
+  @Nullable
+  default List<SegmentFileContainerMetadata> getFileContainers()
   {
     return null;
   }

--- a/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
@@ -40,7 +40,9 @@ import org.apache.druid.segment.column.ConstantColumns;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.Indexed;
 import org.apache.druid.segment.data.ListIndexed;
+import org.apache.druid.segment.file.SegmentFileContainerMetadata;
 import org.apache.druid.segment.file.SegmentFileMapper;
+import org.apache.druid.segment.file.SegmentFileMetadata;
 import org.apache.druid.segment.projections.ClusteredValueGroupsBaseTableSchema;
 import org.apache.druid.segment.projections.Projections;
 import org.apache.druid.segment.projections.QueryableProjection;
@@ -331,6 +333,14 @@ public abstract class SimpleQueryableIndex implements QueryableIndex
   public SegmentFileMapper getFileMapper()
   {
     return fileMapper;
+  }
+
+  @Override
+  @Nullable
+  public List<SegmentFileContainerMetadata> getFileContainers()
+  {
+    final SegmentFileMetadata segmentFileMetadata = fileMapper.getSegmentFileMetadata();
+    return segmentFileMetadata == null ? null : segmentFileMetadata.getContainers();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
@@ -42,6 +42,7 @@ import org.apache.druid.segment.data.Indexed;
 import org.apache.druid.segment.data.ListIndexed;
 import org.apache.druid.segment.file.SegmentFileContainerMetadata;
 import org.apache.druid.segment.file.SegmentFileMapper;
+import org.apache.druid.segment.file.SegmentFileMapperV10;
 import org.apache.druid.segment.file.SegmentFileMetadata;
 import org.apache.druid.segment.projections.ClusteredValueGroupsBaseTableSchema;
 import org.apache.druid.segment.projections.Projections;
@@ -335,6 +336,11 @@ public abstract class SimpleQueryableIndex implements QueryableIndex
     return fileMapper;
   }
 
+  /**
+   * Doesn't include containers from any external mapper {@link #fileMapper} may have attached (see
+   * {@link SegmentFileMapperV10}) — those aren't reflected in {@link SegmentFileMetadata#getContainers()} of the
+   * entry-point mapper, so a bundle whose data spilled into an external file will be undercounted here.
+   */
   @Override
   @Nullable
   public List<SegmentFileContainerMetadata> getFileContainers()
@@ -346,9 +352,7 @@ public abstract class SimpleQueryableIndex implements QueryableIndex
   @Override
   public void close()
   {
-    if (fileMapper != null) {
-      fileMapper.close();
-    }
+    fileMapper.close();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/file/PartialSegmentFileMapperV10.java
+++ b/processing/src/main/java/org/apache/druid/segment/file/PartialSegmentFileMapperV10.java
@@ -378,6 +378,7 @@ public class PartialSegmentFileMapperV10 implements SegmentFileMapper
     this.bitmapLock = new ReentrantLock();
   }
 
+  @Override
   public SegmentFileMetadata getSegmentFileMetadata()
   {
     return metadata;

--- a/processing/src/main/java/org/apache/druid/segment/file/SegmentFileMapper.java
+++ b/processing/src/main/java/org/apache/druid/segment/file/SegmentFileMapper.java
@@ -61,6 +61,13 @@ public interface SegmentFileMapper extends Closeable
     return mapFile(name);
   }
 
+  /**
+   * Returns the {@link SegmentFileMetadata} describing this mapper's containers and internal files, or {@code null}
+   * if unsupported (e.g. legacy pre-V10 mappers that don't track this structure).
+   */
+  @Nullable
+  SegmentFileMetadata getSegmentFileMetadata();
+
   @Override
   void close();
 }

--- a/processing/src/main/java/org/apache/druid/segment/file/SegmentFileMapperV10.java
+++ b/processing/src/main/java/org/apache/druid/segment/file/SegmentFileMapperV10.java
@@ -157,6 +157,7 @@ public class SegmentFileMapperV10 implements SegmentFileMapper
     this.externalMappers = externalMappers;
   }
 
+  @Override
   public SegmentFileMetadata getSegmentFileMetadata()
   {
     return segmentFileMetadata;

--- a/processing/src/test/java/org/apache/druid/query/DoubleStorageTest.java
+++ b/processing/src/test/java/org/apache/druid/query/DoubleStorageTest.java
@@ -145,108 +145,101 @@ public class DoubleStorageTest extends InitializedNullHandlingTest
   @Parameterized.Parameters
   public static Collection<?> dataFeeder()
   {
-    SegmentAnalysis expectedSegmentAnalysisDouble = new SegmentAnalysis(
-        SEGMENT_ID.toString(),
-        ImmutableList.of(INTERVAL),
-        new LinkedHashMap<>(
-            ImmutableMap.of(
-                TIME_COLUMN,
-                new ColumnAnalysis(
-                    ColumnType.LONG,
-                    ValueType.LONG.name(),
-                    false,
-                    false,
-                    100,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
-                DIM_NAME,
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.name(),
-                    false,
-                    false,
-                    120,
-                    1,
-                    DIM_VALUE,
-                    DIM_VALUE,
-                    null
-                ),
-                DIM_FLOAT_NAME,
-                new ColumnAnalysis(
-                    ColumnType.DOUBLE,
-                    ValueType.DOUBLE.name(),
-                    false,
-                    false,
-                    80,
-                    null,
-                    null,
-                    null,
-                    null
+    SegmentAnalysis expectedSegmentAnalysisDouble = new SegmentAnalysis.Builder(SEGMENT_ID)
+        .interval(INTERVAL)
+        .columns(
+            new LinkedHashMap<>(
+                ImmutableMap.of(
+                    TIME_COLUMN,
+                    new ColumnAnalysis(
+                        ColumnType.LONG,
+                        ValueType.LONG.name(),
+                        false,
+                        false,
+                        100,
+                        null,
+                        null,
+                        null,
+                        null
+                    ),
+                    DIM_NAME,
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.name(),
+                        false,
+                        false,
+                        120,
+                        1,
+                        DIM_VALUE,
+                        DIM_VALUE,
+                        null
+                    ),
+                    DIM_FLOAT_NAME,
+                    new ColumnAnalysis(
+                        ColumnType.DOUBLE,
+                        ValueType.DOUBLE.name(),
+                        false,
+                        false,
+                        80,
+                        null,
+                        null,
+                        null,
+                        null
+                    )
                 )
             )
-        ), 330,
-        MAX_ROWS,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+        )
+        .size(330)
+        .numRows(MAX_ROWS)
+        .build();
 
-    SegmentAnalysis expectedSegmentAnalysisFloat = new SegmentAnalysis(
-        SEGMENT_ID.toString(),
-        ImmutableList.of(INTERVAL),
-        new LinkedHashMap<>(
-            ImmutableMap.of(
-                TIME_COLUMN,
-                new ColumnAnalysis(
-                    ColumnType.LONG,
-                    ValueType.LONG.name(),
-                    false,
-                    false,
-                    100,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
-                DIM_NAME,
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.name(),
-                    false,
-                    false,
-                    120,
-                    1,
-                    DIM_VALUE,
-                    DIM_VALUE,
-                    null
-                ),
-                DIM_FLOAT_NAME,
-                new ColumnAnalysis(
-                    ColumnType.FLOAT,
-                    ValueType.FLOAT.name(),
-                    false,
-                    false,
-                    80,
-                    null,
-                    null,
-                    null,
-                    null
+    SegmentAnalysis expectedSegmentAnalysisFloat = new SegmentAnalysis.Builder(SEGMENT_ID)
+        .interval(INTERVAL)
+        .columns(
+            new LinkedHashMap<>(
+                ImmutableMap.of(
+                    TIME_COLUMN,
+                    new ColumnAnalysis(
+                        ColumnType.LONG,
+                        ValueType.LONG.name(),
+                        false,
+                        false,
+                        100,
+                        null,
+                        null,
+                        null,
+                        null
+                    ),
+                    DIM_NAME,
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.name(),
+                        false,
+                        false,
+                        120,
+                        1,
+                        DIM_VALUE,
+                        DIM_VALUE,
+                        null
+                    ),
+                    DIM_FLOAT_NAME,
+                    new ColumnAnalysis(
+                        ColumnType.FLOAT,
+                        ValueType.FLOAT.name(),
+                        false,
+                        false,
+                        80,
+                        null,
+                        null,
+                        null,
+                        null
+                    )
                 )
             )
-        ),
-        330,
-        MAX_ROWS,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+        )
+        .size(330)
+        .numRows(MAX_ROWS)
+        .build();
 
     return ImmutableList.of(
         new Object[]{"double", expectedSegmentAnalysisDouble},

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalysisTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalysisTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.metadata.metadata.ColumnAnalysis;
 import org.apache.druid.query.metadata.metadata.SegmentAnalysis;
+import org.apache.druid.query.metadata.metadata.SegmentAnalysis.ContainerAnalysis;
 import org.apache.druid.segment.AggregateProjectionMetadata;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
@@ -73,14 +74,13 @@ public class SegmentAnalysisTest
         new ColumnAnalysis(ColumnType.DOUBLE, ColumnType.DOUBLE.asTypeString(), true, true, 0, null, null, null, null)
     );
 
-    final SegmentAnalysis analysis = new SegmentAnalysis(
-        "id",
-        Intervals.ONLY_ETERNITY,
-        columns,
-        1,
-        2,
-        ImmutableMap.of("cnt", new CountAggregatorFactory("cnt")),
-        ImmutableMap.of("channel_added_hourly", new AggregateProjectionMetadata(
+    final SegmentAnalysis analysis = new SegmentAnalysis.Builder("id")
+        .intervals(Intervals.ONLY_ETERNITY)
+        .columns(columns)
+        .size(1)
+        .numRows(2)
+        .aggregators(ImmutableMap.of("cnt", new CountAggregatorFactory("cnt")))
+        .projections(ImmutableMap.of("channel_added_hourly", new AggregateProjectionMetadata(
             AggregateProjectionSchema.schemaBuilder("channel_added_hourly")
                                      .timeColumnName(Granularities.GRANULARITY_VIRTUAL_COLUMN_NAME)
                                      .virtualColumns(
@@ -93,11 +93,15 @@ public class SegmentAnalysisTest
                                      .aggregators(new LongSumAggregatorFactory("sum_added", "added"))
                                      .build(),
             16
-        )),
-        TimestampSpec.DEFAULT,
-        Granularities.SECOND,
-        true
-    );
+        )))
+        .timestampSpec(TimestampSpec.DEFAULT)
+        .queryGranularity(Granularities.SECOND)
+        .rollup(true)
+        .containers(ImmutableList.of(
+            new ContainerAnalysis("__base", 223),
+            new ContainerAnalysis("channel_added_hourly", 145)
+        ))
+        .build();
 
     final ObjectMapper jsonMapper = TestHelper.makeJsonMapper();
     final SegmentAnalysis analysis2 = jsonMapper.readValue(
@@ -112,5 +116,8 @@ public class SegmentAnalysisTest
         ImmutableList.copyOf(columns.entrySet()),
         ImmutableList.copyOf(analysis2.getColumns().entrySet())
     );
+
+    // Verify containers survive serde.
+    Assertions.assertEquals(analysis.getContainers(), analysis2.getContainers());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryContainerSizeTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryContainerSizeTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.metadata;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.query.Druids;
+import org.apache.druid.query.QueryPlus;
+import org.apache.druid.query.QueryRunner;
+import org.apache.druid.query.QueryRunnerTestHelper;
+import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
+import org.apache.druid.query.metadata.metadata.SegmentAnalysis;
+import org.apache.druid.query.metadata.metadata.SegmentAnalysis.ContainerAnalysis;
+import org.apache.druid.query.metadata.metadata.SegmentMetadataQuery;
+import org.apache.druid.segment.IndexBuilder;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.QueryableIndexSegment;
+import org.apache.druid.segment.incremental.IncrementalIndexSchema;
+import org.apache.druid.segment.projections.Projections;
+import org.apache.druid.timeline.SegmentId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Verifies {@link SegmentMetadataQuery.AnalysisType#CONTAINERSIZE} against a real V10-format segment: containers are
+ * only populated when the analysis type is requested, and their bundle names line up with the base table and
+ * projection names used at write time.
+ */
+public class SegmentMetadataQueryContainerSizeTest
+{
+  private static final String PROJECTION_NAME = "dim_sum";
+  private static final String DATASOURCE = "containerSizeTestDatasource";
+
+  private static final SegmentMetadataQueryRunnerFactory FACTORY = new SegmentMetadataQueryRunnerFactory(
+      new SegmentMetadataQueryQueryToolChest(new SegmentMetadataQueryConfig()),
+      QueryRunnerTestHelper.NOOP_QUERYWATCHER
+  );
+
+  @Test
+  public void testContainerSizeAnalysis()
+  {
+    final AggregateProjectionSpec projectionSpec =
+        AggregateProjectionSpec.builder(PROJECTION_NAME)
+                                .groupingColumns(new StringDimensionSchema("dim"))
+                                .aggregators(new LongSumAggregatorFactory("m_sum", "m_sum"))
+                                .build();
+
+    final IncrementalIndexSchema schema =
+        IncrementalIndexSchema.builder()
+                              .withDimensionsSpec(new DimensionsSpec(List.of(new StringDimensionSchema("dim"))))
+                              .withMetrics(new LongSumAggregatorFactory("m_sum", "m"))
+                              .withRollup(false)
+                              .withMinTimestamp(DateTimes.of("2013-01-01").getMillis())
+                              .withProjections(List.of(projectionSpec))
+                              .build();
+
+    final List<InputRow> rows = List.of(
+        new MapBasedInputRow(DateTimes.of("2013-01-01"), List.of("dim"), ImmutableMap.of("dim", "a", "m", 1L)),
+        new MapBasedInputRow(DateTimes.of("2013-01-01"), List.of("dim"), ImmutableMap.of("dim", "b", "m", 2L))
+    );
+
+    final File tmpDir = FileUtils.createTempDir();
+    final QueryableIndex index = IndexBuilder.create()
+                                              .useV10()
+                                              .tmpDir(tmpDir)
+                                              .schema(schema)
+                                              .rows(rows)
+                                              .buildMMappedIndex();
+
+    final SegmentId segmentId = SegmentId.dummy(DATASOURCE);
+    final QueryRunner<SegmentAnalysis> runner = QueryRunnerTestHelper.makeQueryRunner(
+        FACTORY,
+        segmentId,
+        new QueryableIndexSegment(index, segmentId),
+        null
+    );
+
+    final SegmentMetadataQuery query =
+        Druids.newSegmentMetadataQueryBuilder()
+              .dataSource(DATASOURCE)
+              .intervals("2013/2014")
+              .analysisTypes(SegmentMetadataQuery.AnalysisType.CONTAINERSIZE)
+              .merge(false)
+              .build();
+
+    final List<SegmentAnalysis> results = runner.run(QueryPlus.wrap(query)).toList();
+    Assert.assertEquals(1, results.size());
+
+    final List<ContainerAnalysis> containers = results.get(0).getContainers();
+    Assert.assertNotNull(containers);
+    Assert.assertEquals(2, containers.size());
+    Assert.assertEquals(Projections.BASE_TABLE_PROJECTION_NAME, containers.get(0).bundle());
+    Assert.assertEquals(PROJECTION_NAME, containers.get(1).bundle());
+
+    final long baseSize = containers.get(0).size();
+    final long projectionSize = containers.get(1).size();
+    // loose upper bound: 2 rows of data should never legitimately serialize to this many bytes; this only catches
+    // gross errors (e.g. reporting an offset or a whole-file size instead of the container's own size).
+    Assert.assertTrue("projection container size should be positive", projectionSize > 0);
+    // the base table has an extra __time column that the (time-less) projection doesn't, so it should be larger.
+    Assert.assertTrue(
+        "base table container should be larger than the projection's (extra __time column)",
+        baseSize > projectionSize
+    );
+    Assert.assertTrue("base table container size looks implausibly large", baseSize < 10_000);
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
@@ -675,6 +675,55 @@ public class SegmentMetadataQueryQueryToolChestTest
     Assert.assertEquals(expectedStrict, mergeWithStrategy(analysis1, analysis2, aggregatorMergeStrategy));
   }
 
+  @EnumSource(AggregatorMergeStrategy.class)
+  @ParameterizedTest(name = "{index}: with AggregatorMergeStrategy {0}")
+  public void testContainers(AggregatorMergeStrategy aggregatorMergeStrategy)
+  {
+    final SegmentAnalysis analysis1 = new SegmentAnalysis.Builder(TEST_SEGMENT_ID1)
+        .container("__base", 100)
+        .container("channel_sum", 50)
+        .build();
+    final SegmentAnalysis analysis2 = new SegmentAnalysis.Builder(TEST_SEGMENT_ID2)
+        .container("__base", 200)
+        .container("channel_sum", 75)
+        .build();
+
+    // merging sums sizes per bundle name, rather than concatenating each segment's raw container list.
+    final SegmentAnalysis expected = new SegmentAnalysis.Builder(
+        "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged")
+        .container("__base", 300)
+        .container("channel_sum", 125)
+        .build();
+    Assert.assertEquals(expected, mergeWithStrategy(analysis1, analysis2, aggregatorMergeStrategy));
+  }
+
+  @EnumSource(AggregatorMergeStrategy.class)
+  @ParameterizedTest(name = "{index}: with AggregatorMergeStrategy {0}")
+  public void testContainersOneSided(AggregatorMergeStrategy aggregatorMergeStrategy)
+  {
+    final SegmentAnalysis analysis1 = new SegmentAnalysis.Builder(TEST_SEGMENT_ID1)
+        .container("__base", 100)
+        .build();
+    final SegmentAnalysis analysis2NoContainers = new SegmentAnalysis.Builder(TEST_SEGMENT_ID2).build();
+
+    // a segment with no container info contributes nothing, rather than nulling out the whole merged result.
+    final SegmentAnalysis expected = new SegmentAnalysis.Builder(
+        "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged")
+        .container("__base", 100)
+        .build();
+    Assert.assertEquals(expected, mergeWithStrategy(analysis1, analysis2NoContainers, aggregatorMergeStrategy));
+  }
+
+  @EnumSource(AggregatorMergeStrategy.class)
+  @ParameterizedTest(name = "{index}: with AggregatorMergeStrategy {0}")
+  public void testContainersBothNull(AggregatorMergeStrategy aggregatorMergeStrategy)
+  {
+    final SegmentAnalysis analysis1 = new SegmentAnalysis.Builder(TEST_SEGMENT_ID1).build();
+    final SegmentAnalysis analysis2 = new SegmentAnalysis.Builder(TEST_SEGMENT_ID2).build();
+
+    Assert.assertNull(mergeWithStrategy(analysis1, analysis2, aggregatorMergeStrategy).getContainers());
+  }
+
   private static SegmentAnalysis mergeWithStrategy(
       SegmentAnalysis analysis1,
       SegmentAnalysis analysis2,

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -235,108 +235,104 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
         new AggregateProjectionMetadata(PROJECTION2_SCHEMA, PROJECTION2_ROWS)
     );
 
-    expectedSegmentAnalysis1 = new SegmentAnalysis(
-        id1.toString(),
-        ImmutableList.of(Intervals.of("2011-01-12T00:00:00.000Z/2011-04-15T00:00:00.001Z")),
-        new LinkedHashMap<>(
-            ImmutableMap.of(
-                "__time",
-                new ColumnAnalysis(
-                    ColumnType.LONG,
-                    ValueType.LONG.toString(),
-                    false,
-                    false,
-                    12090,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
-                "index",
-                new ColumnAnalysis(
-                    ColumnType.DOUBLE,
-                    ValueType.DOUBLE.toString(),
-                    false,
-                    false,
-                    9672,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
-                "placement",
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.toString(),
-                    false,
-                    false,
-                    placementSize,
-                    1,
-                    "preferred",
-                    "preferred",
-                    null
+    expectedSegmentAnalysis1 = new SegmentAnalysis.Builder(id1)
+        .interval(Intervals.of("2011-01-12T00:00:00.000Z/2011-04-15T00:00:00.001Z"))
+        .columns(
+            new LinkedHashMap<>(
+                ImmutableMap.of(
+                    "__time",
+                    new ColumnAnalysis(
+                        ColumnType.LONG,
+                        ValueType.LONG.toString(),
+                        false,
+                        false,
+                        12090,
+                        null,
+                        null,
+                        null,
+                        null
+                    ),
+                    "index",
+                    new ColumnAnalysis(
+                        ColumnType.DOUBLE,
+                        ValueType.DOUBLE.toString(),
+                        false,
+                        false,
+                        9672,
+                        null,
+                        null,
+                        null,
+                        null
+                    ),
+                    "placement",
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.toString(),
+                        false,
+                        false,
+                        placementSize,
+                        1,
+                        "preferred",
+                        "preferred",
+                        null
+                    )
                 )
             )
-        ),
-        overallSize,
-        1209,
-        expectedAggregators,
-        expectedProjections,
-        null,
-        null,
-        null
-    );
-    expectedSegmentAnalysis2 = new SegmentAnalysis(
-        id2.toString(),
-        ImmutableList.of(Intervals.of("2011-01-12T00:00:00.000Z/2011-04-15T00:00:00.001Z")),
-        new LinkedHashMap<>(
-            ImmutableMap.of(
-                "__time",
-                new ColumnAnalysis(
-                    ColumnType.LONG,
-                    ValueType.LONG.toString(),
-                    false,
-                    false,
-                    12090,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
-                "index",
-                new ColumnAnalysis(
-                    ColumnType.DOUBLE,
-                    ValueType.DOUBLE.toString(),
-                    false,
-                    false,
-                    9672,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
-                "placement",
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.toString(),
-                    false,
-                    false,
-                    placementSize,
-                    1,
-                    null,
-                    null,
-                    null
+        )
+        .size(overallSize)
+        .numRows(1209)
+        .aggregators(expectedAggregators)
+        .projections(expectedProjections)
+        .build();
+    expectedSegmentAnalysis2 = new SegmentAnalysis.Builder(id2)
+        .interval(Intervals.of("2011-01-12T00:00:00.000Z/2011-04-15T00:00:00.001Z"))
+        .columns(
+            new LinkedHashMap<>(
+                ImmutableMap.of(
+                    "__time",
+                    new ColumnAnalysis(
+                        ColumnType.LONG,
+                        ValueType.LONG.toString(),
+                        false,
+                        false,
+                        12090,
+                        null,
+                        null,
+                        null,
+                        null
+                    ),
+                    "index",
+                    new ColumnAnalysis(
+                        ColumnType.DOUBLE,
+                        ValueType.DOUBLE.toString(),
+                        false,
+                        false,
+                        9672,
+                        null,
+                        null,
+                        null,
+                        null
+                    ),
+                    "placement",
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.toString(),
+                        false,
+                        false,
+                        placementSize,
+                        1,
+                        null,
+                        null,
+                        null
+                    )
                 )
             )
-        ),
-        overallSize,
-        1209,
-        expectedAggregators,
-        expectedProjections,
-        null,
-        null,
-        null
-    );
+        )
+        .size(overallSize)
+        .numRows(1209)
+        .aggregators(expectedAggregators)
+        .projections(expectedProjections)
+        .build();
   }
 
   @Test
@@ -347,6 +343,7 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
 
     Assert.assertEquals(Collections.singletonList(expectedSegmentAnalysis1), results);
   }
+
 
   @Test
   public void testSegmentMetadataQueryOnRestricted()
@@ -378,45 +375,42 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
   @Test
   public void testSegmentMetadataQueryWithRollupMerge()
   {
-    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis(
-        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString(),
-        null,
-        new LinkedHashMap<>(
-            ImmutableMap.of(
-                "placement",
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.toString(),
-                    false,
-                    false,
-                    0,
-                    0,
-                    null,
-                    null,
-                    null
-                ),
-                "placementish",
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.toString(),
-                    true,
-                    false,
-                    0,
-                    0,
-                    null,
-                    null,
-                    null
+    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis.Builder(
+        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString())
+        .columns(
+            new LinkedHashMap<>(
+                ImmutableMap.of(
+                    "placement",
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.toString(),
+                        false,
+                        false,
+                        0,
+                        0,
+                        null,
+                        null,
+                        null
+                    ),
+                    "placementish",
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.toString(),
+                        true,
+                        false,
+                        0,
+                        0,
+                        null,
+                        null,
+                        null
+                    )
                 )
             )
-        ),
-        0,
-        expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
-        null,
-        null,
-        null,
-        null,
-        rollup1 != rollup2 ? null : rollup1
-    );
+        )
+        .size(0)
+        .numRows(expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows())
+        .rollup(rollup1 != rollup2 ? null : rollup1)
+        .build();
 
     QueryToolChest toolChest = FACTORY.getToolchest();
 
@@ -453,45 +447,41 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
   @Test
   public void testSegmentMetadataQueryWithHasMultipleValuesMerge()
   {
-    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis(
-        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString(),
-        null,
-        new LinkedHashMap<>(
-            ImmutableMap.of(
-                "placement",
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.toString(),
-                    false,
-                    false,
-                    0,
-                    1,
-                    null,
-                    null,
-                    null
-                ),
-                "placementish",
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.toString(),
-                    true,
-                    false,
-                    0,
-                    9,
-                    null,
-                    null,
-                    null
+    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis.Builder(
+        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString())
+        .columns(
+            new LinkedHashMap<>(
+                ImmutableMap.of(
+                    "placement",
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.toString(),
+                        false,
+                        false,
+                        0,
+                        1,
+                        null,
+                        null,
+                        null
+                    ),
+                    "placementish",
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.toString(),
+                        true,
+                        false,
+                        0,
+                        9,
+                        null,
+                        null,
+                        null
+                    )
                 )
             )
-        ),
-        0,
-        expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+        )
+        .size(0)
+        .numRows(expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows())
+        .build();
 
     QueryToolChest toolChest = FACTORY.getToolchest();
 
@@ -528,45 +518,41 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
   @Test
   public void testSegmentMetadataQueryWithComplexColumnMerge()
   {
-    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis(
-        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString(),
-        null,
-        new LinkedHashMap<>(
-            ImmutableMap.of(
-                "placement",
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.toString(),
-                    false,
-                    false,
-                    0,
-                    1,
-                    null,
-                    null,
-                    null
-                ),
-                "quality_uniques",
-                new ColumnAnalysis(
-                    ColumnType.ofComplex("hyperUnique"),
-                    "hyperUnique",
-                    false,
-                    true,
-                    0,
-                    null,
-                    null,
-                    null,
-                    null
+    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis.Builder(
+        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString())
+        .columns(
+            new LinkedHashMap<>(
+                ImmutableMap.of(
+                    "placement",
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.toString(),
+                        false,
+                        false,
+                        0,
+                        1,
+                        null,
+                        null,
+                        null
+                    ),
+                    "quality_uniques",
+                    new ColumnAnalysis(
+                        ColumnType.ofComplex("hyperUnique"),
+                        "hyperUnique",
+                        false,
+                        true,
+                        0,
+                        null,
+                        null,
+                        null,
+                        null
+                    )
                 )
             )
-        ),
-        0,
-        expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+        )
+        .size(0)
+        .numRows(expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows())
+        .build();
 
     QueryToolChest toolChest = FACTORY.getToolchest();
 
@@ -673,52 +659,53 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
       expectedAggregators.put(agg.getName(), agg.getCombiningFactory());
     }
 
-    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis(
-        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString(),
-        ImmutableList.of(expectedSegmentAnalysis1.getIntervals().get(0)),
-        new LinkedHashMap<>(
-            ImmutableMap.of(
-                "__time",
-                new ColumnAnalysis(
-                    ColumnType.LONG,
-                    ValueType.LONG.toString(),
-                    false,
-                    false,
-                    12090 * 2,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
-                "index",
-                new ColumnAnalysis(
-                    ColumnType.DOUBLE,
-                    ValueType.DOUBLE.toString(),
-                    false,
-                    false,
-                    9672 * 2,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
-                column,
-                analysis
+    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis.Builder(
+        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString())
+        .interval(expectedSegmentAnalysis1.getIntervals().get(0))
+        .columns(
+            new LinkedHashMap<>(
+                ImmutableMap.of(
+                    "__time",
+                    new ColumnAnalysis(
+                        ColumnType.LONG,
+                        ValueType.LONG.toString(),
+                        false,
+                        false,
+                        12090 * 2,
+                        null,
+                        null,
+                        null,
+                        null
+                    ),
+                    "index",
+                    new ColumnAnalysis(
+                        ColumnType.DOUBLE,
+                        ValueType.DOUBLE.toString(),
+                        false,
+                        false,
+                        9672 * 2,
+                        null,
+                        null,
+                        null,
+                        null
+                    ),
+                    column,
+                    analysis
+                )
             )
-        ),
-        expectedSegmentAnalysis1.getSize() + expectedSegmentAnalysis2.getSize(),
-        expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
-        expectedAggregators,
-        ImmutableMap.of(
-            PROJECTION1_SCHEMA.getName(),
-            new AggregateProjectionMetadata(PROJECTION1_SCHEMA, PROJECTION1_ROWS * 2),
-            PROJECTION2_SCHEMA.getName(),
-            new AggregateProjectionMetadata(PROJECTION2_SCHEMA, PROJECTION2_ROWS * 2)
-        ),
-        null,
-        null,
-        null
-    );
+        )
+        .size(expectedSegmentAnalysis1.getSize() + expectedSegmentAnalysis2.getSize())
+        .numRows(expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows())
+        .aggregators(expectedAggregators)
+        .projections(
+            ImmutableMap.of(
+                PROJECTION1_SCHEMA.getName(),
+                new AggregateProjectionMetadata(PROJECTION1_SCHEMA, PROJECTION1_ROWS * 2),
+                PROJECTION2_SCHEMA.getName(),
+                new AggregateProjectionMetadata(PROJECTION2_SCHEMA, PROJECTION2_ROWS * 2)
+            )
+        )
+        .build();
 
     QueryToolChest toolChest = FACTORY.getToolchest();
 
@@ -749,33 +736,29 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
   @Test
   public void testSegmentMetadataQueryWithNoAnalysisTypesMerge()
   {
-    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis(
-        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString(),
-        null,
-        new LinkedHashMap<>(
-            ImmutableMap.of(
-                "placement",
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.toString(),
-                    false,
-                    false,
-                    0,
-                    0,
-                    null,
-                    null,
-                    null
+    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis.Builder(
+        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString())
+        .columns(
+            new LinkedHashMap<>(
+                ImmutableMap.of(
+                    "placement",
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.toString(),
+                        false,
+                        false,
+                        0,
+                        0,
+                        null,
+                        null,
+                        null
+                    )
                 )
             )
-        ),
-        0,
-        expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+        )
+        .size(0)
+        .numRows(expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows())
+        .build();
 
     QueryToolChest toolChest = FACTORY.getToolchest();
 
@@ -816,33 +799,30 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
     for (AggregatorFactory agg : TestIndex.METRIC_AGGS) {
       expectedAggregators.put(agg.getName(), agg.getCombiningFactory());
     }
-    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis(
-        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString(),
-        null,
-        new LinkedHashMap<>(
-            ImmutableMap.of(
-                "placement",
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.toString(),
-                    false,
-                    false,
-                    0,
-                    0,
-                    null,
-                    null,
-                    null
+    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis.Builder(
+        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString())
+        .columns(
+            new LinkedHashMap<>(
+                ImmutableMap.of(
+                    "placement",
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.toString(),
+                        false,
+                        false,
+                        0,
+                        0,
+                        null,
+                        null,
+                        null
+                    )
                 )
             )
-        ),
-        0,
-        expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
-        expectedAggregators,
-        null,
-        null,
-        null,
-        null
-    );
+        )
+        .size(0)
+        .numRows(expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows())
+        .aggregators(expectedAggregators)
+        .build();
 
     QueryToolChest toolChest = FACTORY.getToolchest();
 
@@ -883,33 +863,30 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
     for (AggregatorFactory agg : TestIndex.METRIC_AGGS) {
       expectedAggregators.put(agg.getName(), agg.getCombiningFactory());
     }
-    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis(
-        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString(),
-        null,
-        new LinkedHashMap<>(
-            ImmutableMap.of(
-                "placement",
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.toString(),
-                    false,
-                    false,
-                    0,
-                    0,
-                    null,
-                    null,
-                    null
+    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis.Builder(
+        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString())
+        .columns(
+            new LinkedHashMap<>(
+                ImmutableMap.of(
+                    "placement",
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.toString(),
+                        false,
+                        false,
+                        0,
+                        0,
+                        null,
+                        null,
+                        null
+                    )
                 )
             )
-        ),
-        0,
-        expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
-        expectedAggregators,
-        null,
-        null,
-        null,
-        null
-    );
+        )
+        .size(0)
+        .numRows(expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows())
+        .aggregators(expectedAggregators)
+        .build();
 
     QueryToolChest toolChest = FACTORY.getToolchest();
 
@@ -947,33 +924,30 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
   @Test
   public void testSegmentMetadataQueryWithTimestampSpecMerge()
   {
-    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis(
-        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString(),
-        null,
-        new LinkedHashMap<>(
-            ImmutableMap.of(
-                "placement",
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.toString(),
-                    false,
-                    false,
-                    0,
-                    0,
-                    null,
-                    null,
-                    null
+    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis.Builder(
+        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString())
+        .columns(
+            new LinkedHashMap<>(
+                ImmutableMap.of(
+                    "placement",
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.toString(),
+                        false,
+                        false,
+                        0,
+                        0,
+                        null,
+                        null,
+                        null
+                    )
                 )
             )
-        ),
-        0,
-        expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
-        null,
-        null,
-        new TimestampSpec("ts", "iso", null),
-        null,
-        null
-    );
+        )
+        .size(0)
+        .numRows(expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows())
+        .timestampSpec(new TimestampSpec("ts", "iso", null))
+        .build();
 
     QueryToolChest toolChest = FACTORY.getToolchest();
 
@@ -1010,33 +984,30 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
   @Test
   public void testSegmentMetadataQueryWithQueryGranularityMerge()
   {
-    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis(
-        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString(),
-        null,
-        new LinkedHashMap<>(
-            ImmutableMap.of(
-                "placement",
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.toString(),
-                    false,
-                    false,
-                    0,
-                    0,
-                    null,
-                    null,
-                    null
+    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis.Builder(
+        differentIds ? "merged" : SegmentId.dummy(DATASOURCE).toString())
+        .columns(
+            new LinkedHashMap<>(
+                ImmutableMap.of(
+                    "placement",
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.toString(),
+                        false,
+                        false,
+                        0,
+                        0,
+                        null,
+                        null,
+                        null
+                    )
                 )
             )
-        ),
-        0,
-        expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
-        null,
-        null,
-        null,
-        Granularities.NONE,
-        null
-    );
+        )
+        .size(0)
+        .numRows(expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows())
+        .queryGranularity(Granularities.NONE)
+        .build();
 
     QueryToolChest toolChest = FACTORY.getToolchest();
 

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataUnionQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataUnionQueryTest.java
@@ -98,33 +98,29 @@ public class SegmentMetadataUnionQueryTest extends InitializedNullHandlingTest
   @Test
   public void testSegmentMetadataUnionQuery()
   {
-    SegmentAnalysis expected = new SegmentAnalysis(
-        QueryRunnerTestHelper.SEGMENT_ID.toString(),
-        Collections.singletonList(Intervals.of("2011-01-12T00:00:00.000Z/2011-04-15T00:00:00.001Z")),
-        new LinkedHashMap<>(
-            ImmutableMap.of(
-                "placement",
-                new ColumnAnalysis(
-                    ColumnType.STRING,
-                    ValueType.STRING.toString(),
-                    false,
-                    false,
-                    43524,
-                    1,
-                    "preferred",
-                    "preferred",
-                    null
+    SegmentAnalysis expected = new SegmentAnalysis.Builder(QueryRunnerTestHelper.SEGMENT_ID)
+        .interval(Intervals.of("2011-01-12T00:00:00.000Z/2011-04-15T00:00:00.001Z"))
+        .columns(
+            new LinkedHashMap<>(
+                ImmutableMap.of(
+                    "placement",
+                    new ColumnAnalysis(
+                        ColumnType.STRING,
+                        ValueType.STRING.toString(),
+                        false,
+                        false,
+                        43524,
+                        1,
+                        "preferred",
+                        "preferred",
+                        null
+                    )
                 )
             )
-        ),
-        805380,
-        4836,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+        )
+        .size(805380)
+        .numRows(4836)
+        .build();
     SegmentMetadataQuery query = new Druids.SegmentMetadataQueryBuilder()
         .dataSource(QueryRunnerTestHelper.UNION_DATA_SOURCE)
         .intervals(QueryRunnerTestHelper.FULL_ON_INTERVAL_SPEC)

--- a/processing/src/test/java/org/apache/druid/segment/SimpleQueryableIndexClusteredTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/SimpleQueryableIndexClusteredTest.java
@@ -28,6 +28,7 @@ import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.data.ListIndexed;
+import org.apache.druid.segment.file.NoopSegmentFileMapper;
 import org.apache.druid.segment.projections.ClusterGroupSchemaTestHelpers;
 import org.apache.druid.segment.projections.ClusteredValueGroupsBaseTableSchema;
 import org.apache.druid.segment.projections.TableClusterGroupSpec;
@@ -93,7 +94,7 @@ class SimpleQueryableIndexClusteredTest
         new ListIndexed<>(List.of()),
         new RoaringBitmapFactory(),
         Map.of(),                       // clustered summary has no top-level columns
-        null,                           // no SegmentFileMapper for in-memory test
+        NoopSegmentFileMapper.INSTANCE, // no real SegmentFileMapper for in-memory test
         reconstructed,
         projectionColumns,
         summary,
@@ -152,7 +153,7 @@ class SimpleQueryableIndexClusteredTest
         new ListIndexed<>(List.of()),
         new RoaringBitmapFactory(),
         Map.of(),
-        null,
+        NoopSegmentFileMapper.INSTANCE,
         null,
         null
     )

--- a/processing/src/test/java/org/apache/druid/segment/file/NoopSegmentFileMapper.java
+++ b/processing/src/test/java/org/apache/druid/segment/file/NoopSegmentFileMapper.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.file;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.util.Set;
+
+/**
+ * A {@link SegmentFileMapper} with no backing files, for tests that build a
+ * {@link org.apache.druid.segment.SimpleQueryableIndex} purely in-memory and have no real segment file. Use this
+ * instead of a null {@code SegmentFileMapper}, so that {@code fileMapper} is never null and methods like
+ * {@link org.apache.druid.segment.QueryableIndex#getFileContainers()} don't need to guard against it.
+ */
+public class NoopSegmentFileMapper implements SegmentFileMapper
+{
+  public static final NoopSegmentFileMapper INSTANCE = new NoopSegmentFileMapper();
+
+  private NoopSegmentFileMapper()
+  {
+  }
+
+  @Override
+  public Set<String> getInternalFilenames()
+  {
+    return Set.of();
+  }
+
+  @Nullable
+  @Override
+  public ByteBuffer mapFile(String name)
+  {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public SegmentFileMetadata getSegmentFileMetadata()
+  {
+    return null;
+  }
+
+  @Override
+  public void close()
+  {
+  }
+}

--- a/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCacheTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCacheTest.java
@@ -1108,18 +1108,12 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     );
 
     RowSignature signature = AbstractSegmentMetadataCache.analysisToRowSignature(
-        new SegmentAnalysis(
-            "id",
-            ImmutableList.of(Intervals.utc(1L, 2L)),
-            columns,
-            1234,
-            100,
-            null,
-            null,
-            null,
-            null,
-            null
-        )
+        new SegmentAnalysis.Builder("id")
+            .interval(Intervals.utc(1L, 2L))
+            .columns(columns)
+            .size(1234)
+            .numRows(100)
+            .build()
     );
 
     Assert.assertEquals(
@@ -1136,57 +1130,53 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
   public void testSegmentMetadataFallbackType()
   {
     RowSignature signature = AbstractSegmentMetadataCache.analysisToRowSignature(
-        new SegmentAnalysis(
-            "id",
-            ImmutableList.of(Intervals.utc(1L, 2L)),
-            new LinkedHashMap<>(
-                ImmutableMap.of(
-                    "a",
-                    new ColumnAnalysis(
-                        null,
-                        ColumnType.STRING.asTypeString(),
-                        false,
-                        true,
-                        1234,
-                        26,
+        new SegmentAnalysis.Builder("id")
+            .interval(Intervals.utc(1L, 2L))
+            .columns(
+                new LinkedHashMap<>(
+                    ImmutableMap.of(
                         "a",
-                        "z",
-                        null
-                    ),
-                    "count",
-                    new ColumnAnalysis(
-                        null,
-                        ColumnType.LONG.asTypeString(),
-                        false,
-                        true,
-                        1234,
-                        null,
-                        null,
-                        null,
-                        null
-                    ),
-                    "distinct",
-                    new ColumnAnalysis(
-                        null,
-                        "hyperUnique",
-                        false,
-                        true,
-                        1234,
-                        null,
-                        null,
-                        null,
-                        null
+                        new ColumnAnalysis(
+                            null,
+                            ColumnType.STRING.asTypeString(),
+                            false,
+                            true,
+                            1234,
+                            26,
+                            "a",
+                            "z",
+                            null
+                        ),
+                        "count",
+                        new ColumnAnalysis(
+                            null,
+                            ColumnType.LONG.asTypeString(),
+                            false,
+                            true,
+                            1234,
+                            null,
+                            null,
+                            null,
+                            null
+                        ),
+                        "distinct",
+                        new ColumnAnalysis(
+                            null,
+                            "hyperUnique",
+                            false,
+                            true,
+                            1234,
+                            null,
+                            null,
+                            null,
+                            null
+                        )
                     )
                 )
-            ),
-            1234,
-            100,
-            null,
-            null,
-            null,
-            null,
-            null
-        )
+            )
+            .size(1234)
+            .numRows(100)
+            .build()
     );
     Assert.assertEquals(
         RowSignature.builder().add("a", ColumnType.STRING).add("count", ColumnType.LONG).add("distinct", ColumnType.ofComplex("hyperUnique")).build(),
@@ -1211,18 +1201,12 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     columns.put("error_col2", ColumnAnalysis.error("multi_value"));
 
     final RowSignature signature = AbstractSegmentMetadataCache.analysisToRowSignature(
-        new SegmentAnalysis(
-            "id",
-            ImmutableList.of(Intervals.utc(1L, 2L)),
-            columns,
-            1234,
-            100,
-            null,
-            null,
-            null,
-            null,
-            null
-        )
+        new SegmentAnalysis.Builder("id")
+            .interval(Intervals.utc(1L, 2L))
+            .columns(columns)
+            .size(1234)
+            .numRows(100)
+            .build()
     );
 
     Assert.assertEquals(


### PR DESCRIPTION
### Description

Adds a new `SegmentMetadataQuery` analysis type, `CONTAINERSIZE`, that reports the on-disk byte size of each segment's internal storage containers, broken down by the base table and each aggregate projection. This lets a user (or an internal tool) inspect how much storage an individual aggregate projection is adding to a segment, on top of the base table it's derived from.

When `CONTAINERSIZE` is requested, `SegmentAnalysis.getContainers()` returns a list of `(bundle, size)` pairs, one per physical storage container in the segment's V10 file, where `bundle` is either the base table or a projection's name. This is only available for segments written in the V10 segment file format; segments written in the (currently default) V9/legacy format report `null` here.

A few implementation notes:
- `QueryableIndex.getFileContainers()` is the new extension point sourcing this data, implemented by `SimpleQueryableIndex`/`PartialQueryableIndex` via `SegmentFileMapper.getSegmentFileMetadata()`; `SmooshedFileMapper` (legacy) explicitly returns `null` since the legacy format has no container/bundle structure to report.
- When merging analyses across segments, container sizes are summed by bundle name.


#### Release note

Added a new `CONTAINERSIZE` segment metadata analysis type that reports the on-disk byte size of each segment's storage containers, broken down by the base table and each aggregate projection. This makes it possible to see how much storage an individual projection is adding to a segment. Only available for segments written in the V10 segment file format.

<hr>

##### Key changed/added classes in this PR
* `SegmentMetadataQuery`
* `SegmentAnalysis`
* `SegmentAnalysis.ContainerAnalysis`
* `SegmentMetadataQueryRunnerFactory`
* `SegmentMetadataQueryQueryToolChest`
* `QueryableIndex`


<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
