### PR TITLE
docs: document pull request guidance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,13 @@ Real-time analytics database. Java, Maven, multi-module project.
 - End every file with a newline.
 - Don't format changes unnecessarily.
 
+## Pull Requests
+
+- PR titles targeting `master` must use the Conventional Commits format: `<type>: <description>` or `<type>(<scope>): <description>`.
+- Accepted types are `backport`, `build`, `ci`, `dev`, `docs`, `feat`, `fix`, `minor`, `perf`, `refactor`, `release`, `revert`, `style`, and `test`.
+- Example: `build: remove redundant license download step`.
+- Follow `.github/pull_request_template.md` when preparing the PR description.
+
 ## Running Tests
 
 Use these flags for faster tests: `-Pskip-static-checks -Dweb.console.skip=true -T1C`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Real-time analytics database. Java, Maven, multi-module project.
 ## Pull Requests
 
 - PR titles targeting `master` must use the Conventional Commits format: `<type>: <description>` or `<type>(<scope>): <description>`.
+- For a breaking change, add `!` immediately before the colon: `<type>!: <description>` or `<type>(<scope>)!: <description>`. A breaking change is backward-incompatible and may require users to update existing code, configuration, or integrations.
 - Accepted types are `backport`, `build`, `ci`, `dev`, `docs`, `feat`, `fix`, `minor`, `perf`, `refactor`, `release`, `revert`, `style`, and `test`.
 - Example: `build: remove redundant license download step`.
 - Follow `.github/pull_request_template.md` when preparing the PR description.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Real-time analytics database. Java, Maven, multi-module project.
 
 ## Pull Requests
 
+- Before opening a PR, self-review the complete diff against the target branch. Verify that every change is intentional and in scope, check for correctness and regressions, and run the relevant tests or checks.
 - PR titles targeting `master` must use the Conventional Commits format: `<type>: <description>` or `<type>(<scope>): <description>`.
 - For a breaking change, add `!` immediately before the colon: `<type>!: <description>` or `<type>(<scope>)!: <description>`. A breaking change is backward-incompatible and may require users to update existing code, configuration, or integrations.
 - Accepted types are `backport`, `build`, `ci`, `dev`, `docs`, `feat`, `fix`, `minor`, `perf`, `refactor`, `release`, `revert`, `style`, and `test`.


### PR DESCRIPTION
### Description

Document pull request preparation requirements in `AGENTS.md` so coding agents review their complete change and use a valid title before opening a PR against `master`.

The new guidance includes:

- a requirement to self-review the complete diff against the target branch;
- the supported Conventional Commits title formats, including the `!` marker for breaking changes;
- the accepted types configured by the PR title check;
- an example title; and
- a reminder to follow the pull request template when preparing the description.

This helps agents catch unintended or incorrect changes before publishing and avoids preventable failures in the `Verify PR title conforms to Conventional Commits` check. It does not affect Druid runtime behavior.

### Verification

- Confirmed that the documented types match `.github/workflows/pr-checks.yml`.
- Self-reviewed the complete diff against the target branch.
- Ran `git diff --check`.
- No runtime tests were run because this change only updates agent guidance.

This PR has:

- [x] been self-reviewed.
- [x] added documentation for a repository contribution requirement.
