### PR TITLE
fix: synchronize GraalVM JavaScript context access in JavaScriptTieredBrokerSelectorStrategy (#18253) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/services/src/main/java/org/apache/druid/server/router/JavaScriptTieredBrokerSelectorStrategy.java
+++ b/services/src/main/java/org/apache/druid/server/router/JavaScriptTieredBrokerSelectorStrategy.java
@@ -53,9 +53,11 @@ public class JavaScriptTieredBrokerSelectorStrategy implements TieredBrokerSelec
   }
 
   @Override
-  public Optional<String> getBrokerServiceName(TieredBrokerConfig config, Query query)
+  public synchronized Optional<String> getBrokerServiceName(TieredBrokerConfig config, Query query)
   {
-    fnSelector = fnSelector == null ? JavaScriptUtil.compileSelectorFunction(SelectorFunction.class, function) : fnSelector;
+    if (fnSelector == null) {
+      fnSelector = JavaScriptUtil.compileSelectorFunction(SelectorFunction.class, function);
+    }
     return Optional.fromNullable(fnSelector.apply(config, query));
   }
 


### PR DESCRIPTION
Fixes #18253

## Problem
GraalVM JS engine throws `IllegalStateException: Multi threaded access requested` when the same JavaScript context is accessed from multiple threads simultaneously. The `JavaScriptTieredBrokerSelectorStrategy` shares a single compiled JavaScript function across all broker routing threads, which triggers this error.

## Root cause
`JavaScriptUtil.compileSelectorFunction()` creates a GraalVM `ScriptEngine` that is not thread-safe. The `fnSelector` field is lazily initialized with a non-atomic check-then-write pattern, and `fnSelector.apply()` is called from multiple Jetty handler threads without synchronization.

## Fix
1. Add `synchronized` to `getBrokerServiceName()` to serialize all access to the shared GraalVM context
2. Simplify the lazy initialization to a straightforward if-null check (protected by the synchronized block)

## Testing
- Existing tests pass as-is (the test creates a single-threaded test, which is unaffected)
- The fix prevents the `Multi threaded access requested` error in production Router deployments

CC: @jtuglu1