### PR TITLE
test(processing): avoid flaky incremental index cursor ordering

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexCursorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexCursorFactoryTest.java
@@ -232,11 +232,14 @@ public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTe
 
     Assert.assertEquals(2, results.size());
 
-    ResultRow row = results.get(0);
-    Assert.assertArrayEquals(new Object[]{null, "bo", 1L}, row.getArray());
-
-    row = results.get(1);
-    Assert.assertArrayEquals(new Object[]{"hi", null, 1L}, row.getArray());
+    // GroupingEngine.process returns raw grouped results without applying the query's order-by post-processing.
+    // The result order is therefore not guaranteed when the incremental index is not sorted by dimensions.
+    Assert.assertTrue(
+        results.stream().anyMatch(row -> Arrays.deepEquals(new Object[]{null, "bo", 1L}, row.getArray()))
+    );
+    Assert.assertTrue(
+        results.stream().anyMatch(row -> Arrays.deepEquals(new Object[]{"hi", null, 1L}, row.getArray()))
+    );
   }
 
   @Test


### PR DESCRIPTION
## Summary

Make `IncrementalIndexCursorFactoryTest.testSanity` independent of result sequence order.

`GroupingEngine.process` returns the raw grouped sequence and does not apply the query's `ORDER BY` post-processing. When the incremental index is not sorted by dimensions, positional assertions on the returned rows are not valid.

## Evidence

The original failure occurred in the JDK 25 unit-test shard:

- [Failed CI job](https://github.com/apache/druid/actions/runs/30748065218/job/91497026107)
- Failing case: `testSanity[1: onheap, sortByDim: false]`
- Failure: expected the row beginning with `null`, but received the row beginning with `hi`

Before this change, the focused test was run 10 times locally on JDK 25 and reproduced the same failure twice. This confirms that the failure is nondeterministic rather than a deterministic assertion failure.

## Changes

Replace positional row assertions with order-independent assertions while retaining validation of both expected result rows.

## Tests

- Focused parameterized class: 16 tests, 0 failures, 1 skipped
- Focused `testSanity` repeated 10 times on JDK 25 after the change: 10/10 passed
