### PR TITLE
fix: acquire cached unmount race

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -1299,8 +1299,20 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
                                 );
           }
           if (complete.isMounted()) {
+            // the entry is already mounted, so hand back its cached reference provider. Read the volatile
+            // referenceProvider exactly once, inside the supplier, rather than trusting the isMounted() check above and
+            // reading the field again when the supplier runs later: for a static (non-virtual-storage) entry a
+            // concurrent drop (release() -> unmount()) can null it in between. The reservation hold does not prevent
+            // this (it only guards weak entries against reclaim), so a weak entry would stay mounted here, but a
+            // static entry can be unmounted out from under us. A dropped entry is reported as absent (empty) rather
+            // than reloaded.
             return new AcquireSegmentAction(
-                () -> Futures.immediateFuture(AcquireSegmentResult.cached(complete.referenceProvider)),
+                () -> {
+                  final ReferenceCountedSegmentProvider provider = complete.referenceProvider;
+                  return Futures.immediateFuture(
+                      provider != null ? AcquireSegmentResult.cached(provider) : AcquireSegmentResult.empty()
+                  );
+                },
                 hold
             );
           } else {

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
@@ -919,6 +919,37 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testAcquireExistingSegmentDroppedBeforeSupplierRunsReportsAbsent() throws Exception
+  {
+    final DataSegment segmentToLoad = makeTestDataSegment(segmentDeepStorageDir);
+    final File localSegmentFile = new File(segmentDeepStorageDir, TEST_DATA_RELATIVE_PATH);
+    makeSegmentZip(
+        localSegmentFile,
+        new File(segmentDeepStorageDir.getCanonicalPath() + "/" + TEST_DATA_RELATIVE_PATH + "/index.zip")
+    );
+
+    manager.load(segmentToLoad);
+    Assert.assertTrue("segment should be cached (static, mounted) after load", manager.isSegmentCached(segmentToLoad));
+
+    // Take the already-loaded fast path, but do NOT invoke the supplier yet (getSegmentFuture() is what runs it).
+    final AcquireSegmentAction action = manager.acquireSegment(segmentToLoad, AcquireMode.FULL);
+
+    // Drop the segment: for a static entry release() unmounts it immediately, nulling referenceProvider out from
+    // under the still-outstanding (no-op) hold.
+    manager.drop(segmentToLoad);
+
+    // Invoking the supplier now must not NPE; the segment is reported absent (empty) instead.
+    final AcquireSegmentResult result = action.getSegmentFuture().get();
+    Assert.assertNotNull("reference provider must never be null", result.getReferenceProvider());
+    Assert.assertFalse(
+        "a segment dropped before the supplier ran should be reported absent",
+        result.getReferenceProvider().acquireReference().isPresent()
+    );
+
+    action.close();
+  }
+
+  @Test
   public void testVirtualStorageRejectsNonPositiveLoadThreads()
   {
     final StorageLocationConfig locationConfig = new StorageLocationConfig(localSegmentCacheDir, 10000L, null);


### PR DESCRIPTION
### Description
Fixes a race that can occur when acquiring a cached segment if it is unmounted before the reference provider can be fetched. The fix is to return an empty result instead of null (which can cause a npe).